### PR TITLE
[Celebrimbor] Referencia CLI basada en repo oficial vercel-labs/skills

### DIFF
--- a/prompts/celebrimbor/celebrimbor-main.md
+++ b/prompts/celebrimbor/celebrimbor-main.md
@@ -52,15 +52,19 @@ Este prompt principal carga todos los módulos de Celebrimbor:
 
 ### Módulos de Operaciones (CRUD)
 
-7. **07-module-search.md** - Búsqueda de skills ✅ Tarea #3
-8. **08-module-install.md** - Instalación de skills ✅ Tarea #4
-9. **09-module-list.md** - Listar skills instaladas ✅ Tarea #3/4
-10. **10-module-remove.md** - Eliminar skills ✅ Tarea #5
-11. **11-module-update.md** - Actualizar skills ✅ Tarea #6
+7. **07-module-search.md** - Búsqueda de skills
+8. **08-module-install.md** - Instalación de skills
+9. **09-module-list.md** - Listar skills instaladas
+10. **10-module-remove.md** - Eliminar skills
+11. **11-module-update.md** - Actualizar skills
+
+### Referencia Técnica
+
+12. **14-skills-cli-reference.md** - Referencia CLI oficial (vercel-labs/skills)
 
 ### Módulos Futuros (v2.2+)
-- **12-mode-auto.md** - Modo automático (Tarea #7)
-- **13-integration-palantir.md** - Integración Palantír (Tarea #11)
+- **12-mode-auto.md** - Modo automático
+- **13-integration-palantir.md** - Integración Palantír
 
 ---
 

--- a/prompts/celebrimbor/sections/04-backend-cli.md
+++ b/prompts/celebrimbor/sections/04-backend-cli.md
@@ -4,6 +4,9 @@
 
 Implementar el backend que usa `npx skills` (Node.js) para gestionar skills.
 
+> **Referencia CLI completa**: Ver `sections/14-skills-cli-reference.md`
+> **Fuente oficial**: [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills)
+
 ---
 
 ## 🎯 Requisitos
@@ -28,29 +31,15 @@ npx skills --version  # Debe funcionar
 
 **Comando CLI**:
 ```bash
-npx skills search <query>
+npx skills find [query]
 ```
 
-**Ejemplo**:
+> **IMPORTANTE**: El comando es `find`, NO `search`.
+
+**Ejemplos**:
 ```bash
-npx skills search playwright
-```
-
-**Output esperado**:
-```
-🔍 Searching for "playwright"...
-
-Found 12 skills:
-
-  playwright-pom                    vercel-labs/skills
-  Page Object Model patterns for Playwright
-  1,523 installs
-
-  playwright-fixtures               playwright-community
-  Custom test fixtures for Playwright
-  892 installs
-
-  ...
+npx skills find playwright   # Buscar por keyword
+npx skills find              # Modo interactivo
 ```
 
 **Parseo**:
@@ -58,52 +47,44 @@ Found 12 skills:
 - Formatear como lista estructurada
 - Mostrar al usuario de forma clara
 
+**Alternativa** — listar skills de un repo sin instalar:
+```bash
+npx skills add vercel-labs/agent-skills --list
+```
+
 ---
 
 ### 2. **Instalar Skill**
 
 **Comando CLI**:
 ```bash
-npx skills add <owner/repo/skill-name>
+npx skills add <source> [options]
 ```
 
-**Ejemplo**:
+**Flags clave**:
+- `-a claude-code` → agente destino
+- `-s <skill-name>` → skill específica
+- `-g` → instalar en global
+- `-y` → no interactivo
+- `--copy` → copiar en vez de symlink
+
+**Ejemplos**:
 ```bash
-# Instalación global
-npx skills add vercel-labs/skills/playwright-pom
+# Instalar skill específica para Claude Code (no interactivo)
+npx skills add vercel-labs/agent-skills -s playwright-pom -a claude-code -y
 
-# El CLI preguntará la ubicación:
-# ? Where should this skill be installed?
-#   > Global (~/.claude/skills/)
-#     Local (./.claude/rules/)
+# Instalar en global
+npx skills add vercel-labs/agent-skills -s playwright-pom -g -a claude-code -y
+
+# Ver skills disponibles antes de instalar
+npx skills add vercel-labs/agent-skills --list
 ```
-
-**Automatización**:
-- NO modo interactivo (evitar preguntas del CLI)
-- Usar flags si están disponibles
-- Copiar manualmente si es necesario
 
 **Proceso**:
-1. Ejecutar `npx skills add <skill>`
-2. Si pide ubicación → responder automáticamente
+1. Ejecutar `npx skills add` con flags `-a claude-code -s <skill> -y`
+2. Si es global: añadir `-g`
 3. Verificar instalación exitosa
 4. Confirmar path final del archivo
-
-**Configuración de `paths:`**:
-
-Si la skill requiere `paths:`, añadir después de instalar:
-
-```yaml
-# En ~/.claude/skills/playwright-pom.md o ./.claude/rules/playwright-pom.md
-
----
-paths:
-  - "tests/**/*.spec.ts"
-  - "pages/**/*.ts"
----
-
-# Contenido de la skill...
-```
 
 ---
 
@@ -111,68 +92,116 @@ paths:
 
 **Comando CLI**:
 ```bash
-npx skills list
+npx skills list [options]
+npx skills ls [options]
 ```
 
-**Output esperado**:
+**Flags**:
+- `-g` → solo globales
+- `-a claude-code` → filtrar por agente
+
+**Ejemplos**:
+```bash
+npx skills list                  # Todas las instaladas
+npx skills ls -g                 # Solo globales
+npx skills ls -a claude-code     # Solo de Claude Code
 ```
-📦 Installed skills:
 
-Global (~/.claude/skills/):
-  - playwright-pom (vercel-labs/skills)
-  - typescript-utils (community/typescript)
-
-Local (./.claude/rules/):
-  - php-symfony (custom)
-```
-
-**Complementar con lectura manual**:
-
-Si `npx skills list` no existe, leer directorios:
+**Fallback** (lectura manual de directorios):
 ```bash
 # Global
 ls -1 ~/.claude/skills/*.md
+ls -1 ~/.claude/rules/*.md
 
 # Local
+ls -1 ./.claude/skills/*.md
 ls -1 ./.claude/rules/*.md
 ```
 
 ---
 
-### 4. **Actualizar Skill**
+### 4. **Verificar Actualizaciones**
 
 **Comando CLI**:
 ```bash
-npx skills update <skill-name>
+npx skills check
 ```
 
-**Ejemplo**:
+**Comportamiento**: Compara skills instaladas con sus fuentes remotas.
+
+---
+
+### 5. **Actualizar Skills**
+
+**Comando CLI**:
 ```bash
-npx skills update playwright-pom
+npx skills update
 ```
 
-**Fallback** (si comando no existe):
+> **NOTA**: Actualiza TODAS las skills de golpe. No acepta nombre individual.
+
+**Fallback** (reinstalar skill específica):
 ```bash
-# Re-instalar skill (sobreescribe)
-npx skills add vercel-labs/skills/playwright-pom --force
+npx skills add <source> -s <skill-name> -a claude-code -y
 ```
 
 ---
 
-### 5. **Eliminar Skill**
+### 6. **Eliminar Skill**
 
 **Comando CLI**:
 ```bash
-npx skills remove <skill-name>
+npx skills remove [skill] [options]
+npx skills rm [skill] [options]
 ```
 
-**Fallback** (si comando no existe):
+**Flags**:
+- `-g` → scope global
+- `-a claude-code` → agente específico
+- `-y` → sin confirmación
+- `--all` → eliminar todo
+
+**Ejemplos**:
 ```bash
-# Eliminar archivo manualmente
+npx skills remove playwright-pom -a claude-code -y   # Específica
+npx skills remove -g my-skill                         # Desde global
+npx skills remove --all                               # Todo
+```
+
+**Fallback** (eliminar archivo manualmente):
+```bash
 rm ~/.claude/skills/playwright-pom.md
-# o
 rm ./.claude/rules/playwright-pom.md
 ```
+
+---
+
+### 7. **Crear Plantilla de Skill**
+
+**Comando CLI**:
+```bash
+npx skills init [name]
+```
+
+**Comportamiento**:
+- Sin nombre: crea `SKILL.md` en directorio actual
+- Con nombre: crea subdirectorio con `SKILL.md`
+
+---
+
+## 📍 Scopes de Instalación
+
+| Scope | Flag | Ubicación | Uso |
+|-------|------|-----------|-----|
+| **Project** | (default) | `.claude/skills/` | Compartido via repo |
+| **Global** | `-g` | `~/.claude/skills/` | Personal, todos los proyectos |
+
+## 🔗 Métodos de Instalación
+
+| Método | Flag | Descripción |
+|--------|------|-------------|
+| **Symlink** | (default) | Referencia a copia canónica. Recomendado. |
+| **Copy** | `--copy` | Copia independiente. Usar si symlinks fallan. |
 
 ---
 
@@ -191,18 +220,10 @@ Requerido:   v18.0.0+
 
 Opciones:
 1. Actualizar Node.js → Usar Backend CLI
-2. Esperar v2.2.0 → Usar Backend Git (sin Node.js)
-
-Ver instrucciones: docs/REQUISITOS.md
+2. Esperar v4.0.0 → Usar Backend Git (sin Node.js)
 ```
 
 ### Error: Skill no encontrada
-
-**Comando falla**:
-```bash
-npx skills add non-existent-skill
-# Error: Skill not found
-```
 
 **Acción**:
 ```
@@ -212,7 +233,7 @@ La skill "non-existent-skill" no existe en skills.sh
 
 Sugerencias:
 - Verificar nombre (sensible a mayúsculas)
-- Buscar alternativas: npx skills search <query>
+- Buscar alternativas: npx skills find <query>
 - Ver catálogo: https://skills.sh
 ```
 
@@ -238,51 +259,34 @@ Instala npm:
 backend_cli:
   name: "cli"
   available: true (si Node.js >=18)
-  version: "1.0.0"
+  version: "2.0.0"
 
   operations:
-    search:   "npx skills search {query}"
-    install:  "npx skills add {skill}"
-    list:     "npx skills list" + lectura manual
-    update:   "npx skills update {skill}"
-    remove:   "npx skills remove {skill}" o rm manual
+    search:   "npx skills find {query}"
+    install:  "npx skills add {source} -s {skill} -a claude-code -y"
+    list:     "npx skills list" / "npx skills ls -a claude-code"
+    check:    "npx skills check"
+    update:   "npx skills update"
+    remove:   "npx skills remove {skill} -a claude-code -y"
+    init:     "npx skills init {name}"
 ```
-
----
-
-## 📦 Optimizaciones
-
-### Cache de Skills Disponibles
-
-Para evitar llamar `npx skills search` repetidamente:
-
-```yaml
-# ~/.celebrimbor/cache/skills-index.yml
-cached_at: "2026-02-15T10:30:00Z"
-ttl: 3600  # 1 hora
-
-skills:
-  - name: "playwright-pom"
-    author: "vercel-labs"
-    ...
-```
-
-**Invalidar cache**:
-- Después de 1 hora
-- Si usuario ejecuta "Actualizar índice"
 
 ---
 
 ## 🎯 Reglas de Ejecución
 
 1. **SIEMPRE validar Node.js** antes de ejecutar comandos
-2. **Capturar y parsear** output de npx skills
-3. **Manejo robusto de errores** (skill no existe, network fail, etc.)
-4. **Confirmación al usuario** antes de instalar/eliminar
-5. **Verificar instalación** después de cada operación
+2. **Usar `find`** para buscar, NUNCA `search`
+3. **Usar flags `-a claude-code -y`** para operaciones no interactivas
+4. **Capturar y parsear** output de npx skills
+5. **Manejo robusto de errores** (skill no existe, network fail, etc.)
+6. **Confirmación al usuario** antes de instalar/eliminar
+7. **Verificar instalación** después de cada operación
+8. **Consultar** `14-skills-cli-reference.md` ante cualquier duda de sintaxis
 
 ---
 
 **Módulo anterior**: 03-abstraction-layer.md
-**Módulo siguiente**: 05-backend-git.md (hooks para v2.2.0)
+**Módulo siguiente**: 05-backend-git.md (v4.0.0)
 **Módulo relacionado**: 06-backend-selector.md
+**Referencia CLI**: 14-skills-cli-reference.md

--- a/prompts/celebrimbor/sections/14-skills-cli-reference.md
+++ b/prompts/celebrimbor/sections/14-skills-cli-reference.md
@@ -1,0 +1,299 @@
+# 📖 Referencia CLI skills.sh - Celebrimbor
+
+## Fuente
+
+Referencia basada en el repositorio oficial [`vercel-labs/skills`](https://github.com/vercel-labs/skills).
+Web: [skills.sh](https://skills.sh) | Docs: [skills.sh/docs](https://skills.sh/docs)
+
+---
+
+## 🔧 Comandos Disponibles
+
+### 1. `skills add` — Instalar skills
+
+**Sintaxis**:
+```bash
+npx skills add <source> [options]
+```
+
+**Flags**:
+
+| Flag | Descripción |
+|------|-------------|
+| `-g, --global` | Instalar en directorio global del usuario (`~/`) |
+| `-a, --agent <agents...>` | Agentes destino (ej: `claude-code`, `cursor`) |
+| `-s, --skill <skills...>` | Instalar skills específicas por nombre |
+| `-l, --list` | Mostrar skills disponibles sin instalar |
+| `--copy` | Copiar archivos en vez de symlink |
+| `-y, --yes` | Saltar confirmaciones (no interactivo) |
+| `--all` | Instalar todo: `--skill '*' --agent '*' -y` |
+
+**Formatos de source aceptados**:
+- GitHub shorthand: `owner/repo`
+- URL completa: `https://github.com/owner/repo`
+- Path directo a skill: `https://github.com/owner/repo/tree/main/skills/skill-name`
+- GitLab: `https://gitlab.com/org/repo`
+- SSH: `git@github.com:owner/repo.git`
+- Local: `./my-local-skills`
+
+**Ejemplos**:
+```bash
+# Listar skills de un repo antes de instalar
+npx skills add vercel-labs/agent-skills --list
+
+# Instalar skill específica para Claude Code (no interactivo)
+npx skills add vercel-labs/agent-skills -s frontend-design -a claude-code -y
+
+# Instalar en global
+npx skills add vercel-labs/agent-skills -s frontend-design -g -a claude-code -y
+
+# Instalar todas las skills de un repo para Claude Code
+npx skills add vercel-labs/agent-skills --skill '*' -a claude-code -y
+
+# Una skill para todos los agentes
+npx skills add vercel-labs/agent-skills --agent '*' -s frontend-design -y
+
+# Skills con espacios en el nombre (requieren comillas)
+npx skills add owner/repo -s "Convex Best Practices" -a claude-code -y
+```
+
+---
+
+### 2. `skills find` — Buscar skills
+
+**Sintaxis**:
+```bash
+npx skills find [query]
+```
+
+**Comportamiento**:
+- Sin query: modo interactivo (busca en skills.sh)
+- Con query: busca por keyword
+
+**Ejemplos**:
+```bash
+npx skills find              # Interactivo
+npx skills find typescript   # Buscar por keyword
+npx skills find playwright   # Buscar por keyword
+```
+
+> **IMPORTANTE**: El comando es `find`, NO `search`. El comando `search` no existe.
+
+---
+
+### 3. `skills list` / `skills ls` — Listar skills instaladas
+
+**Sintaxis**:
+```bash
+npx skills list [options]
+npx skills ls [options]
+```
+
+**Flags**:
+
+| Flag | Descripción |
+|------|-------------|
+| `-g, --global` | Solo skills globales |
+| `-a, --agent <agents...>` | Filtrar por agente |
+
+**Ejemplos**:
+```bash
+npx skills list                          # Todas las instaladas
+npx skills ls -g                         # Solo globales
+npx skills ls -a claude-code             # Solo de Claude Code
+npx skills ls -a claude-code -a cursor   # De Claude Code y Cursor
+```
+
+---
+
+### 4. `skills check` — Detectar actualizaciones
+
+**Sintaxis**:
+```bash
+npx skills check
+```
+
+**Comportamiento**:
+- Compara skills instaladas con sus fuentes remotas
+- Muestra cuáles tienen actualizaciones disponibles
+
+---
+
+### 5. `skills update` — Aplicar actualizaciones
+
+**Sintaxis**:
+```bash
+npx skills update
+```
+
+**Comportamiento**:
+- Actualiza TODAS las skills que tienen actualizaciones pendientes
+- No acepta nombre de skill individual (actualiza todo de golpe)
+
+> **NOTA**: No existe `npx skills update <skill-name>`. Se actualizan todas a la vez.
+
+---
+
+### 6. `skills init` — Crear plantilla de skill
+
+**Sintaxis**:
+```bash
+npx skills init [name]
+```
+
+**Comportamiento**:
+- Sin nombre: crea `SKILL.md` en el directorio actual
+- Con nombre: crea subdirectorio con `SKILL.md` dentro
+
+**Ejemplo**:
+```bash
+npx skills init                # Crea ./SKILL.md
+npx skills init my-skill       # Crea ./my-skill/SKILL.md
+```
+
+---
+
+### 7. `skills remove` / `skills rm` — Desinstalar skills
+
+**Sintaxis**:
+```bash
+npx skills remove [skill] [options]
+npx skills rm [skill] [options]
+```
+
+**Flags**:
+
+| Flag | Descripción |
+|------|-------------|
+| `-g, --global` | Buscar en scope global |
+| `-a, --agent <agents...>` | Especificar agentes (`'*'` para todos) |
+| `-s, --skill <skills...>` | Especificar skills (`'*'` para todas) |
+| `-y, --yes` | Saltar confirmaciones |
+| `--all` | Eliminar todo: `--skill '*' --agent '*' -y` |
+
+**Ejemplos**:
+```bash
+npx skills remove                                    # Interactivo
+npx skills remove web-design-guidelines              # Skill específica
+npx skills remove -g my-skill                        # Desde global
+npx skills remove -a claude-code -a cursor my-skill  # De agentes específicos
+npx skills remove --all                              # Eliminar todo
+```
+
+---
+
+## 📍 Scopes de Instalación
+
+| Scope | Flag | Ubicación | Uso |
+|-------|------|-----------|-----|
+| **Project** | (default) | `./<agent>/skills/` | Compartido via repo (versionable) |
+| **Global** | `-g` | `~/<agent>/skills/` | Personal, disponible en todos los proyectos |
+
+### Ubicaciones para Claude Code
+
+| Scope | Path |
+|-------|------|
+| Project skills | `.claude/skills/` |
+| Project rules | `.claude/rules/` |
+| Global skills | `~/.claude/skills/` |
+| Global rules | `~/.claude/rules/` |
+
+---
+
+## 🔗 Métodos de Instalación
+
+| Método | Flag | Descripción |
+|--------|------|-------------|
+| **Symlink** | (default) | Referencia a copia canónica. Single source of truth. Recomendado. |
+| **Copy** | `--copy` | Copia independiente por agente. Usar cuando symlinks no funcionan. |
+
+---
+
+## 📄 Estructura de SKILL.md
+
+Las skills son directorios con un fichero `SKILL.md` que usa frontmatter YAML:
+
+```markdown
+---
+name: my-skill
+description: Brief explanation of functionality
+---
+
+# My Skill
+
+Instructions for agent activation.
+
+## When to Use
+
+Scenario descriptions.
+
+## Steps
+
+1. First action
+2. Second action
+```
+
+**Campos obligatorios**: `name` + `description`
+
+**Campos opcionales**:
+- `metadata.internal: true` — Oculta la skill del descubrimiento normal (solo visible con `INSTALL_INTERNAL_SKILLS=1`)
+
+---
+
+## 🌍 Variables de Entorno
+
+| Variable | Propósito |
+|----------|-----------|
+| `INSTALL_INTERNAL_SKILLS=1` | Incluir skills internas/ocultas en búsqueda |
+| `DISABLE_TELEMETRY` | Desactivar telemetría anónima |
+| `DO_NOT_TRACK` | Alternativa para desactivar telemetría |
+
+---
+
+## ⚠️ Errores Comunes y Prevención
+
+| Error | Causa | Solución |
+|-------|-------|----------|
+| "No skills found" | `SKILL.md` sin `name` o `description` en frontmatter | Verificar YAML frontmatter |
+| Skill no carga | Path incorrecto o frontmatter inválido | Verificar ubicación y formato |
+| Permission errors | Sin permisos de escritura | Verificar permisos del directorio destino |
+| `search` no reconocido | Comando incorrecto | Usar `find` en vez de `search` |
+
+---
+
+## 🎯 Cheatsheet Rápido para Celebrimbor
+
+```bash
+# Buscar
+npx skills find <query>
+
+# Instalar (Claude Code, no interactivo)
+npx skills add <owner/repo> -s <skill-name> -a claude-code -y
+
+# Instalar global
+npx skills add <owner/repo> -s <skill-name> -g -a claude-code -y
+
+# Listar
+npx skills list
+npx skills ls -a claude-code
+
+# Verificar updates
+npx skills check
+
+# Actualizar todas
+npx skills update
+
+# Crear skill nueva
+npx skills init <name>
+
+# Eliminar
+npx skills remove <skill-name> -a claude-code -y
+
+# Ver disponibles sin instalar
+npx skills add <owner/repo> --list
+```
+
+---
+
+**Fuente oficial**: [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills)
+**Última verificación**: 2026-02-26


### PR DESCRIPTION
## Summary

- Nuevo módulo `14-skills-cli-reference.md` con referencia CLI completa extraída del repo oficial [`vercel-labs/skills`](https://github.com/vercel-labs/skills)
- Actualizado `04-backend-cli.md` para alinear comandos y flags con la realidad (ej: `find` en vez de `search`, flags `-a`, `-s`, `-g`, `-y`)
- Registrado módulo 14 en `celebrimbor-main.md`

Closes #54
Supersedes #47

## Cambios clave

| Antes (incorrecto) | Ahora (real) |
|---------------------|--------------|
| `npx skills search` | `npx skills find` |
| `npx skills add <owner/repo/skill>` | `npx skills add <source> -s <skill> -a claude-code -y` |
| `npx skills update <skill>` | `npx skills update` (todas a la vez) |
| Sin flags documentados | `-g`, `-a`, `-s`, `-l`, `-y`, `--copy`, `--all` |
| Sin `init` | `npx skills init [name]` |

## Test plan

- [ ] Verificar que Celebrimbor usa `find` en vez de `search` al buscar skills
- [ ] Verificar instalación con flags correctos: `npx skills add <repo> -s <skill> -a claude-code -y`
- [ ] Verificar que la referencia 14 se carga correctamente desde celebrimbor-main

🤖 Generated with [Claude Code](https://claude.com/claude-code)