### PR TITLE
feat(tlotp): reemplazar docs hardcodeadas por WebFetch live (#64)

### DIFF
--- a/prompts/celebrimbor/sections/04-backend-cli.md
+++ b/prompts/celebrimbor/sections/04-backend-cli.md
@@ -4,8 +4,14 @@
 
 Implementar el backend que usa `npx skills` (Node.js) para gestionar skills.
 
-> **Referencia CLI completa**: Ver `sections/14-skills-cli-reference.md`
+> **Referencia CLI completa**: Ver `sections/14-skills-cli-reference.md` (obtiene docs live via WebFetch)
 > **Fuente oficial**: [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills)
+
+## 📖 Documentación Oficial (Live)
+
+**ANTES de ejecutar operaciones**, el módulo 14 obtiene la referencia CLI actualizada via WebFetch.
+Este módulo define la **lógica operacional** de cómo Celebrimbor usa el CLI.
+Para sintaxis y flags exactos, consultar siempre el módulo 14.
 
 ---
 

--- a/prompts/celebrimbor/sections/14-skills-cli-reference.md
+++ b/prompts/celebrimbor/sections/14-skills-cli-reference.md
@@ -1,267 +1,60 @@
 # 📖 Referencia CLI skills.sh - Celebrimbor
 
-## Fuente
+## 📖 Documentación Oficial (Live)
 
-Referencia basada en el repositorio oficial [`vercel-labs/skills`](https://github.com/vercel-labs/skills).
-Web: [skills.sh](https://skills.sh) | Docs: [skills.sh/docs](https://skills.sh/docs)
+**ANTES de ejecutar comandos CLI**, obtener la referencia actualizada desde DOS fuentes:
 
----
+> **WebFetch 1**: https://github.com/vercel-labs/skills
+> **Extraer**:
+> - Comandos disponibles: `add`, `find`, `list/ls`, `check`, `update`, `init`, `remove/rm`
+> - Flags por comando (especialmente `-g`, `-a`, `-s`, `-l`, `-y`, `--copy`, `--all`)
+> - Formatos de source aceptados (GitHub shorthand, URL, SSH, local)
+> - Scopes de instalación (project vs global)
+> - Métodos de instalación (symlink vs copy)
+> - Estructura de SKILL.md (frontmatter YAML)
+> - Variables de entorno
 
-## 🔧 Comandos Disponibles
+> **WebFetch 2**: https://code.claude.com/docs/en/skills
+> **Extraer**:
+> - Sistema de skills nativo de Claude Code
+> - Ubicaciones de skills (enterprise, personal, project, plugin)
+> - Frontmatter fields disponibles
+> - Control de invocación (disable-model-invocation, user-invocable)
+> - Patrones avanzados (context fork, supporting files)
 
-### 1. `skills add` — Instalar skills
-
-**Sintaxis**:
-```bash
-npx skills add <source> [options]
-```
-
-**Flags**:
-
-| Flag | Descripción |
-|------|-------------|
-| `-g, --global` | Instalar en directorio global del usuario (`~/`) |
-| `-a, --agent <agents...>` | Agentes destino (ej: `claude-code`, `cursor`) |
-| `-s, --skill <skills...>` | Instalar skills específicas por nombre |
-| `-l, --list` | Mostrar skills disponibles sin instalar |
-| `--copy` | Copiar archivos en vez de symlink |
-| `-y, --yes` | Saltar confirmaciones (no interactivo) |
-| `--all` | Instalar todo: `--skill '*' --agent '*' -y` |
-
-**Formatos de source aceptados**:
-- GitHub shorthand: `owner/repo`
-- URL completa: `https://github.com/owner/repo`
-- Path directo a skill: `https://github.com/owner/repo/tree/main/skills/skill-name`
-- GitLab: `https://gitlab.com/org/repo`
-- SSH: `git@github.com:owner/repo.git`
-- Local: `./my-local-skills`
-
-**Ejemplos**:
-```bash
-# Listar skills de un repo antes de instalar
-npx skills add vercel-labs/agent-skills --list
-
-# Instalar skill específica para Claude Code (no interactivo)
-npx skills add vercel-labs/agent-skills -s frontend-design -a claude-code -y
-
-# Instalar en global
-npx skills add vercel-labs/agent-skills -s frontend-design -g -a claude-code -y
-
-# Instalar todas las skills de un repo para Claude Code
-npx skills add vercel-labs/agent-skills --skill '*' -a claude-code -y
-
-# Una skill para todos los agentes
-npx skills add vercel-labs/agent-skills --agent '*' -s frontend-design -y
-
-# Skills con espacios en el nombre (requieren comillas)
-npx skills add owner/repo -s "Convex Best Practices" -a claude-code -y
-```
+**Usar la información obtenida como fuente de verdad** para todas las operaciones CLI.
 
 ---
 
-### 2. `skills find` — Buscar skills
+## 🎯 Propósito
 
-**Sintaxis**:
-```bash
-npx skills find [query]
-```
+Referencia técnica del CLI de skills.sh para que Celebrimbor ejecute operaciones correctamente.
 
-**Comportamiento**:
-- Sin query: modo interactivo (busca en skills.sh)
-- Con query: busca por keyword
-
-**Ejemplos**:
-```bash
-npx skills find              # Interactivo
-npx skills find typescript   # Buscar por keyword
-npx skills find playwright   # Buscar por keyword
-```
-
-> **IMPORTANTE**: El comando es `find`, NO `search`. El comando `search` no existe.
+**Fuentes oficiales**:
+- CLI: [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills)
+- Skills nativos: [code.claude.com/docs/en/skills](https://code.claude.com/docs/en/skills)
+- Web: [skills.sh](https://skills.sh)
 
 ---
 
-### 3. `skills list` / `skills ls` — Listar skills instaladas
+## ⚠️ Errores Comunes (Verificados)
 
-**Sintaxis**:
-```bash
-npx skills list [options]
-npx skills ls [options]
-```
-
-**Flags**:
-
-| Flag | Descripción |
-|------|-------------|
-| `-g, --global` | Solo skills globales |
-| `-a, --agent <agents...>` | Filtrar por agente |
-
-**Ejemplos**:
-```bash
-npx skills list                          # Todas las instaladas
-npx skills ls -g                         # Solo globales
-npx skills ls -a claude-code             # Solo de Claude Code
-npx skills ls -a claude-code -a cursor   # De Claude Code y Cursor
-```
-
----
-
-### 4. `skills check` — Detectar actualizaciones
-
-**Sintaxis**:
-```bash
-npx skills check
-```
-
-**Comportamiento**:
-- Compara skills instaladas con sus fuentes remotas
-- Muestra cuáles tienen actualizaciones disponibles
-
----
-
-### 5. `skills update` — Aplicar actualizaciones
-
-**Sintaxis**:
-```bash
-npx skills update
-```
-
-**Comportamiento**:
-- Actualiza TODAS las skills que tienen actualizaciones pendientes
-- No acepta nombre de skill individual (actualiza todo de golpe)
-
-> **NOTA**: No existe `npx skills update <skill-name>`. Se actualizan todas a la vez.
-
----
-
-### 6. `skills init` — Crear plantilla de skill
-
-**Sintaxis**:
-```bash
-npx skills init [name]
-```
-
-**Comportamiento**:
-- Sin nombre: crea `SKILL.md` en el directorio actual
-- Con nombre: crea subdirectorio con `SKILL.md` dentro
-
-**Ejemplo**:
-```bash
-npx skills init                # Crea ./SKILL.md
-npx skills init my-skill       # Crea ./my-skill/SKILL.md
-```
-
----
-
-### 7. `skills remove` / `skills rm` — Desinstalar skills
-
-**Sintaxis**:
-```bash
-npx skills remove [skill] [options]
-npx skills rm [skill] [options]
-```
-
-**Flags**:
-
-| Flag | Descripción |
-|------|-------------|
-| `-g, --global` | Buscar en scope global |
-| `-a, --agent <agents...>` | Especificar agentes (`'*'` para todos) |
-| `-s, --skill <skills...>` | Especificar skills (`'*'` para todas) |
-| `-y, --yes` | Saltar confirmaciones |
-| `--all` | Eliminar todo: `--skill '*' --agent '*' -y` |
-
-**Ejemplos**:
-```bash
-npx skills remove                                    # Interactivo
-npx skills remove web-design-guidelines              # Skill específica
-npx skills remove -g my-skill                        # Desde global
-npx skills remove -a claude-code -a cursor my-skill  # De agentes específicos
-npx skills remove --all                              # Eliminar todo
-```
-
----
-
-## 📍 Scopes de Instalación
-
-| Scope | Flag | Ubicación | Uso |
-|-------|------|-----------|-----|
-| **Project** | (default) | `./<agent>/skills/` | Compartido via repo (versionable) |
-| **Global** | `-g` | `~/<agent>/skills/` | Personal, disponible en todos los proyectos |
-
-### Ubicaciones para Claude Code
-
-| Scope | Path |
-|-------|------|
-| Project skills | `.claude/skills/` |
-| Project rules | `.claude/rules/` |
-| Global skills | `~/.claude/skills/` |
-| Global rules | `~/.claude/rules/` |
-
----
-
-## 🔗 Métodos de Instalación
-
-| Método | Flag | Descripción |
-|--------|------|-------------|
-| **Symlink** | (default) | Referencia a copia canónica. Single source of truth. Recomendado. |
-| **Copy** | `--copy` | Copia independiente por agente. Usar cuando symlinks no funcionan. |
-
----
-
-## 📄 Estructura de SKILL.md
-
-Las skills son directorios con un fichero `SKILL.md` que usa frontmatter YAML:
-
-```markdown
----
-name: my-skill
-description: Brief explanation of functionality
----
-
-# My Skill
-
-Instructions for agent activation.
-
-## When to Use
-
-Scenario descriptions.
-
-## Steps
-
-1. First action
-2. Second action
-```
-
-**Campos obligatorios**: `name` + `description`
-
-**Campos opcionales**:
-- `metadata.internal: true` — Oculta la skill del descubrimiento normal (solo visible con `INSTALL_INTERNAL_SKILLS=1`)
-
----
-
-## 🌍 Variables de Entorno
-
-| Variable | Propósito |
-|----------|-----------|
-| `INSTALL_INTERNAL_SKILLS=1` | Incluir skills internas/ocultas en búsqueda |
-| `DISABLE_TELEMETRY` | Desactivar telemetría anónima |
-| `DO_NOT_TRACK` | Alternativa para desactivar telemetría |
-
----
-
-## ⚠️ Errores Comunes y Prevención
+Estos errores fueron verificados contra la documentación real y se mantienen como referencia rápida:
 
 | Error | Causa | Solución |
 |-------|-------|----------|
-| "No skills found" | `SKILL.md` sin `name` o `description` en frontmatter | Verificar YAML frontmatter |
+| `search` no reconocido | Comando incorrecto | Usar `find` en vez de `search` |
+| "No skills found" | `SKILL.md` sin `name` o `description` | Verificar YAML frontmatter |
 | Skill no carga | Path incorrecto o frontmatter inválido | Verificar ubicación y formato |
 | Permission errors | Sin permisos de escritura | Verificar permisos del directorio destino |
-| `search` no reconocido | Comando incorrecto | Usar `find` en vez de `search` |
+
+> **IMPORTANTE**: El comando de búsqueda es `find`, NO `search`.
 
 ---
 
-## 🎯 Cheatsheet Rápido para Celebrimbor
+## 🎯 Cheatsheet Rápido (Verificado)
+
+Estos comandos son correctos según la documentación oficial:
 
 ```bash
 # Buscar
@@ -296,4 +89,4 @@ npx skills add <owner/repo> --list
 ---
 
 **Fuente oficial**: [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills)
-**Última verificación**: 2026-02-26
+**Índice de fuentes**: `@prompts/docs-sources.md`

--- a/prompts/celebrimbor/sections/15-module-post-install-rules.md
+++ b/prompts/celebrimbor/sections/15-module-post-install-rules.md
@@ -6,6 +6,18 @@ Tras instalar una skill, ofrecer al usuario crear una **rule con frontmatter `pa
 
 ---
 
+## 📖 Documentación Oficial (Live)
+
+**ANTES de ejecutar este módulo**, obtener información actualizada sobre rules con paths:
+
+> **WebFetch**: https://code.claude.com/docs/en/memory
+> **Extraer**: Sección "Modular rules with .claude/rules/", específicamente:
+> - Estructura básica de `.claude/rules/`
+> - Path-specific rules con frontmatter YAML `paths:`
+> - Glob patterns soportados (incluyendo brace expansion)
+> - Subdirectorios y symlinks
+> - User-level rules vs project-level rules
+
 ## Contexto: Por qué Rules con Paths
 
 Las rules con `paths:` son el **mecanismo nativo de Claude Code** para activación contextual de skills:

--- a/prompts/docs-sources.md
+++ b/prompts/docs-sources.md
@@ -1,0 +1,117 @@
+# 📖 Fuentes de Documentación Oficial - TLOTP
+
+> **Índice central** de URLs oficiales que TLOTP consulta via WebFetch.
+> Ningún módulo debe hardcodear documentación: siempre fetch live.
+
+---
+
+## 🔗 Documentación Oficial de Claude Code
+
+### Memoria y Configuración
+
+| URL | Qué contiene | Épicas que lo usan |
+|-----|-------------|-------------------|
+| https://code.claude.com/docs/en/memory | Jerarquía de memoria (7 niveles), rules con `paths:`, imports `@`, auto memory, best practices | Palantír, Celebrimbor |
+
+**Qué extraer**: Tipos de memoria, ubicaciones de archivos, jerarquía de precedencia, sistema de rules con paths, estructura de auto memory.
+
+---
+
+### Hooks
+
+| URL | Qué contiene | Épicas que lo usan |
+|-----|-------------|-------------------|
+| https://code.claude.com/docs/en/hooks-guide | Guía completa de hooks: 3 tipos (command, prompt, agent), todos los eventos, matchers, configuración en settings.json, ejemplos prácticos | Palantír (#52) |
+
+**Qué extraer**: Tipos de hooks, tabla de eventos con matchers, formatos de input/output JSON, exit codes, configuración por scope, ejemplos de auto-format, block files, notifications.
+
+**Suplemento** (info práctica en español no cubierta por docs oficiales):
+> WebFetch: https://wmedia.es/es/articulos/claude-code-hooks-guia-practica
+> Extraer: casos de uso prácticos, tips y patrones comunes en español.
+
+---
+
+### Skills
+
+| URL | Qué contiene | Épicas que lo usan |
+|-----|-------------|-------------------|
+| https://code.claude.com/docs/en/skills | Sistema de skills nativo: SKILL.md, frontmatter, invocation control, context fork, supporting files, slash commands | Celebrimbor |
+
+**Qué extraer**: Estructura de SKILL.md, campos de frontmatter, ubicaciones (enterprise/personal/project/plugin), control de invocación, patrones avanzados.
+
+---
+
+### CLI de skills.sh (vercel-labs/skills)
+
+| URL | Qué contiene | Épicas que lo usan |
+|-----|-------------|-------------------|
+| https://github.com/vercel-labs/skills | CLI `npx skills`: 7 comandos (add, find, list, check, update, init, remove), flags, scopes, formatos de source | Celebrimbor |
+
+**Qué extraer**: Comandos disponibles, flags por comando, scopes de instalación, métodos (symlink vs copy), estructura de SKILL.md, variables de entorno.
+
+---
+
+### Sub-agentes
+
+| URL | Qué contiene | Épicas que lo usan |
+|-----|-------------|-------------------|
+| https://code.claude.com/docs/en/sub-agents | Sub-agentes: built-in (Explore, Plan, general-purpose), custom agents, frontmatter, tools, permissions, hooks, memory | Aragorn, general |
+
+**Qué extraer**: Built-in subagents, configuración de custom agents, campos de frontmatter, permission modes, persistent memory, hooks en subagents.
+
+---
+
+### Agent Teams
+
+| URL | Qué contiene | Épicas que lo usan |
+|-----|-------------|-------------------|
+| https://code.claude.com/docs/en/agent-teams | Agent Teams nativos: lead + teammates, shared task list, mailbox, display modes, best practices, limitaciones | Aragorn |
+
+**Qué extraer**: Arquitectura (lead, teammates, task list, mailbox), habilitación (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`), control de equipos, display modes, mejores prácticas, limitaciones conocidas.
+
+---
+
+### Output Styles
+
+| URL | Qué contiene | Épicas que lo usan |
+|-----|-------------|-------------------|
+| https://code.claude.com/docs/en/output-styles | Output styles: built-in (Default, Explanatory, Learning), custom styles, frontmatter, relación con CLAUDE.md | Palantír |
+
+**Qué extraer**: Estilos disponibles, cómo crear custom styles, frontmatter, diferencias con CLAUDE.md y skills.
+
+---
+
+## 📋 Cómo Usar Este Índice
+
+### Para módulos de TLOTP
+
+Cada módulo que necesite documentación oficial debe:
+
+1. **Referenciar este fichero** como índice de fuentes
+2. **Usar WebFetch** a la URL correspondiente antes de ejecutar
+3. **Extraer solo lo relevante** para su función específica
+4. **NO hardcodear** el contenido de la documentación
+
+### Patrón de uso en módulos
+
+```markdown
+## 📖 Documentación Oficial (Live)
+
+**ANTES de ejecutar este módulo**, consultar documentación actualizada:
+
+> **WebFetch**: [URL del índice docs-sources.md]
+> **Extraer**: [campos específicos que necesita este módulo]
+
+Usar la información obtenida como fuente de verdad.
+```
+
+### Nota sobre WebFetch
+
+- Requiere que el usuario haya aprobado el permiso WebFetch (ver PASO 1.5 en tlotp-main.md)
+- Si WebFetch no está disponible, informar al usuario y ofrecer alternativas
+- Las URLs se verificaron por última vez: 2026-02-27
+
+---
+
+*Fuente única de verdad para documentación externa de TLOTP*
+*Última actualización: 2026-02-27*

--- a/prompts/info_claude.md
+++ b/prompts/info_claude.md
@@ -1,227 +1,42 @@
 # 📚 Información Oficial de Claude Code Memory
 
-> Fuente: https://code.claude.com/docs/en/memory
-
-Esta información se usa para proporcionar contexto al usuario durante operaciones de reset/recovery.
-
----
-
-## 🗂️ Tipos de Memoria de Claude Code
-
-### 1. Managed Policy (Políticas de Organización)
-
-**Ubicación**:
-- macOS: `/Library/Application Support/ClaudeCode/CLAUDE.md`
-- Linux: `/etc/claude-code/CLAUDE.md`
-- Windows: `C:\Program Files\ClaudeCode\CLAUDE.md`
-
-**Propósito**: Instrucciones a nivel organizacional gestionadas por IT/DevOps
-
-**Ejemplos de uso**:
-- Estándares de código de la empresa
-- Políticas de seguridad
-- Requisitos de cumplimiento
-
-**Compartido con**: Todos los usuarios de la organización
-
-**⚠️ IMPORTANTE**: NUNCA modificar en reset (es responsabilidad de IT/DevOps)
+> **IMPORTANTE**: Este módulo ya NO contiene documentación hardcodeada.
+> Toda la información se obtiene live via WebFetch.
 
 ---
 
-### 2. User Memory (Memoria Personal Global)
+## 📖 Documentación Oficial (Live)
 
-**Ubicación**: `~/.claude/CLAUDE.md`
+**ANTES de usar esta información**, obtener documentación actualizada:
 
-**Propósito**: Preferencias personales que aplican a TODOS tus proyectos
+> **WebFetch**: https://code.claude.com/docs/en/memory
+> **Extraer**:
+> - Tipos de memoria (7 niveles): Managed Policy, User Memory, User Rules, Project Memory, Project Rules, Project Local, Auto Memory
+> - Ubicaciones de archivos por cada tipo
+> - Jerarquía de precedencia (más específico gana)
+> - Sistema de @imports
+> - Rules con frontmatter `paths:` para activación contextual
+> - Auto memory: estructura, primeras 200 líneas, topic files
+> - Best practices por tipo de memoria
 
-**Ejemplos de uso**:
-- Preferencias de estilo de código
-- Atajos de herramientas personales
-- Convenciones de naming preferidas
-- Stack tecnológico que dominas
-
-**Compartido con**: Solo tú (todos tus proyectos)
-
-**Reset**: Mejor **vaciar** que borrar (mantener el archivo indica que existe)
-
----
-
-### 3. User Rules (Reglas Personales Modulares)
-
-**Ubicación**: `~/.claude/rules/*.md`
-
-**Propósito**: Reglas personales organizadas por tema
-
-**Ejemplos de uso**:
-- Guías específicas de lenguaje
-- Convenciones de testing
-- Estándares de API
-
-**Compartido con**: Solo tú (todos tus proyectos)
-
-**Reset**: **Borrar archivos .md individuales**, mantener directorio
-
-**Características**:
-- Soporta subdirectorios para organización
-- Soporta symlinks a reglas compartidas
-- Puede tener frontmatter YAML con `paths:` para reglas condicionales
+**Usar la información obtenida como fuente de verdad** para operaciones de reset, recovery, inspección y configuración.
 
 ---
 
-### 4. Project Memory (Memoria del Proyecto Compartida)
+## 🎯 Propósito de Este Módulo
 
-**Ubicación**: `./CLAUDE.md` o `./.claude/CLAUDE.md`
-
-**Propósito**: Instrucciones del proyecto compartidas con el equipo
-
-**Ejemplos de uso**:
-- Arquitectura del proyecto
-- Estándares de código del equipo
-- Flujos de trabajo comunes
-
-**Compartido con**: Miembros del equipo (vía control de versiones)
-
-**Reset**: **Vaciar o borrar** (si está en git, mejor vaciar para mantener el archivo versionado)
-
-**Características**:
-- Soporta @imports de otros archivos
-- Claude Code busca CLAUDE.md recursivamente hacia arriba desde el directorio actual
+Este fichero es referenciado por:
+- **Palantír**: Para inspección de jerarquía oficial y operaciones de reset/recovery
+- **Celebrimbor**: Para configuración de paths en rules tras instalar skills
 
 ---
 
-### 5. Project Rules (Reglas del Proyecto Modulares)
+## 📋 Índice de Fuentes Completo
 
-**Ubicación**: `./.claude/rules/*.md`
-
-**Propósito**: Instrucciones modulares del proyecto con paths específicos
-
-**Ejemplos de uso**:
-- Guías específicas de lenguaje
-- Convenciones de testing
-- Estándares de API
-
-**Compartido con**: Miembros del equipo (vía control de versiones)
-
-**Reset**: **Borrar archivos .md individuales**, mantener directorio `./.claude/rules/`
-
-**Características**:
-- Soporta frontmatter YAML con `paths:` para reglas condicionales
-- Soporta subdirectorios
-- Soporta symlinks
+Para todas las fuentes de documentación oficial de TLOTP, ver:
+> `@prompts/docs-sources.md`
 
 ---
 
-### 6. Project Local (Memoria Personal del Proyecto)
-
-**Ubicación**: `./CLAUDE.local.md`
-
-**Propósito**: Preferencias personales específicas del proyecto (NO en git)
-
-**Ejemplos de uso**:
-- URLs de sandbox personales
-- Datos de prueba preferidos
-- Configuraciones locales
-
-**Compartido con**: Solo tú (proyecto actual)
-
-**Reset**: **Borrar** (no está versionado, se regenera fácil)
-
-**Características**:
-- Automáticamente añadido a `.gitignore`
-- Ideal para preferencias privadas que no deben estar en git
-
----
-
-### 7. Auto Memory (Notas Automáticas de Claude)
-
-**Ubicación**: `~/.claude/projects/<project>/memory/`
-
-**Propósito**: Notas automáticas que Claude escribe para sí mismo
-
-**Ejemplos de contenido**:
-- Patrones del proyecto (comandos de build, convenciones de test)
-- Insights de debugging (soluciones a problemas, causas de errores)
-- Notas de arquitectura (archivos clave, relaciones entre módulos)
-- Tus preferencias (estilo de comunicación, hábitos de flujo de trabajo)
-
-**Compartido con**: Solo tú (por proyecto)
-
-**Reset**: **Borrar MEMORY.md y topic files** (Claude los regenera)
-
-**Estructura**:
-```
-~/.claude/projects/<project>/memory/
-├── MEMORY.md          # Índice conciso (primeras 200 líneas se cargan)
-├── debugging.md       # Notas detalladas de debugging
-├── api-conventions.md # Decisiones de diseño de API
-└── ...                # Otros topic files que Claude crea
-```
-
-**Características**:
-- Solo las primeras 200 líneas de MEMORY.md se cargan automáticamente
-- Topic files se leen bajo demanda cuando Claude los necesita
-- Claude lee y escribe estos archivos durante la sesión
-
----
-
-## 📊 Jerarquía de Prioridad
-
-Instrucciones más específicas tienen precedencia sobre las más amplias:
-
-1. **Project Local** (más específico)
-2. **Project Rules**
-3. **Project Memory**
-4. **User Rules**
-5. **User Memory**
-6. **Managed Policy** (más amplio)
-
----
-
-## 🔧 Sistema de @imports
-
-CLAUDE.md puede importar archivos adicionales:
-
-```markdown
-@path/to/file.md
-@~/global-preferences.md
-@README.md
-```
-
-**Características**:
-- Paths relativos y absolutos permitidos
-- Imports recursivos (max depth: 5)
-- Primera vez en un proyecto: diálogo de aprobación
-
----
-
-## 💡 Mejores Prácticas
-
-**User Memory**:
-- Sé específico: "Usa 2 espacios de indentación" > "Formatea código correctamente"
-- Organiza con headings markdown
-- Revisa periódicamente
-
-**Project Memory**:
-- Incluye comandos frecuentes (build, test, lint)
-- Documenta estilo de código y convenciones de naming
-- Añade patrones arquitectónicos importantes
-
-**Rules**:
-- Mantén reglas enfocadas (un tema por archivo)
-- Usa nombres descriptivos
-- Usa `paths:` solo cuando las reglas aplican a archivos específicos
-- Organiza con subdirectorios
-
----
-
-## ⚠️ Notas Importantes
-
-- **Managed Policy**: NUNCA modificar (responsabilidad de IT)
-- **CLAUDE.local.md**: Automáticamente en `.gitignore`
-- **Auto Memory**: Claude lo gestiona, pero puedes editarlo manualmente
-- **Symlinks**: Soportados en rules/ para compartir reglas entre proyectos
-
----
-
-*Información extraída de la documentación oficial de Claude Code*
-*Última actualización: 2026-02-13*
+*Información obtenida live de la documentación oficial de Claude Code*
+*Índice de fuentes: prompts/docs-sources.md*

--- a/prompts/palantir/sections/03-jerarquia-oficial.md
+++ b/prompts/palantir/sections/03-jerarquia-oficial.md
@@ -1,6 +1,24 @@
 # 📋 Inspección de Jerarquía Oficial
 
-Debes inspeccionar **TODA la jerarquía oficial de memoria** de Claude Code en el siguiente orden:
+## 📖 Documentación Oficial (Live)
+
+**ANTES de ejecutar la inspección**, obtener la jerarquía actualizada:
+
+> **WebFetch**: https://code.claude.com/docs/en/memory
+> **Extraer**:
+> - Tabla completa de tipos de memoria (ubicaciones, propósitos, scope)
+> - Jerarquía de precedencia
+> - Estructura de auto memory
+> - Sistema de rules con paths
+> - Sistema de @imports
+
+**Usar la información obtenida como fuente de verdad** para todos los niveles de inspección.
+
+---
+
+## Procedimiento de Inspección
+
+Debes inspeccionar **TODA la jerarquía oficial de memoria** de Claude Code en el orden que indique la documentación oficial.
 
 ## Para CADA ubicación de memoria:
 
@@ -12,27 +30,21 @@ Debes inspeccionar **TODA la jerarquía oficial de memoria** de Claude Code en e
 
 ---
 
-## 🏢 1. Managed Policy (Organización)
+## Niveles de Inspección
 
-**Descripción**: Políticas organizacionales gestionadas por IT/DevOps.
+Inspeccionar cada nivel según la documentación oficial obtenida via WebFetch.
+Para cada nivel, seguir estas instrucciones específicas:
 
-**Ubicaciones según OS** (busca en la correspondiente):
-- **Linux**: `/etc/claude-code/CLAUDE.md`
-- **macOS**: `/Library/Application Support/ClaudeCode/CLAUDE.md`
-- **Windows**: `C:\Program Files\ClaudeCode\CLAUDE.md`
+### Managed Policy (Organización)
 
 **Qué mostrar**:
-- PATH completo del archivo
+- PATH completo del archivo (según OS detectado)
 - STATUS (✅/❌/⚠️)
 - Contenido completo si existe
 
 ---
 
-## 👤 2. User Memory (Personal - Global)
-
-**Descripción**: Preferencias personales que aplican a todos los proyectos.
-
-**Ubicación**: `~/.claude/CLAUDE.md`
+### User Memory (Personal - Global)
 
 **Qué mostrar**:
 - PATH completo
@@ -42,14 +54,10 @@ Debes inspeccionar **TODA la jerarquía oficial de memoria** de Claude Code en e
 
 ---
 
-## 📚 3. User Rules (Personal - Modular)
-
-**Descripción**: Reglas personales organizadas por tema.
-
-**Ubicación**: `~/.claude/rules/*.md`
+### User Rules (Personal - Modular)
 
 **Qué mostrar**:
-- PATH del directorio `~/.claude/rules/`
+- PATH del directorio
 - Listar TODOS los archivos `.md` recursivamente (incluyendo subdirectorios)
 - Para cada archivo:
   - PATH completo
@@ -57,77 +65,33 @@ Debes inspeccionar **TODA la jerarquía oficial de memoria** de Claude Code en e
   - Contenido completo del archivo
   - Si es symlink, indicar a qué apunta
 
-**Ejemplo de archivo con paths**:
-```markdown
----
-paths:
-  - "src/**/*.ts"
-  - "lib/**/*.ts"
 ---
 
-# TypeScript Rules
-[contenido...]
-```
-
----
-
-## 📁 4. Project Memory (Equipo - Compartido)
-
-**Descripción**: Instrucciones compartidas del proyecto con el equipo (en git).
-
-**Ubicaciones posibles** (buscar ambas):
-1. `./CLAUDE.md` (raíz del proyecto)
-2. `./.claude/CLAUDE.md` (directorio oculto)
-
-**Además, buscar recursivamente hacia ARRIBA**:
-- Desde el directorio actual, busca CLAUDE.md en cada directorio padre hasta la raíz
-- Ejemplo: Si estás en `/project/src/components/`, buscar en:
-  - `/project/src/components/CLAUDE.md`
-  - `/project/src/CLAUDE.md`
-  - `/project/CLAUDE.md`
+### Project Memory (Equipo - Compartido)
 
 **Qué mostrar**:
-- Todos los CLAUDE.md encontrados (del actual hacia arriba)
-- Para cada uno: PATH, STATUS, contenido
+- Buscar en ambas ubicaciones posibles (raíz y directorio oculto)
+- Buscar recursivamente hacia ARRIBA hasta la raíz
+- Para cada CLAUDE.md encontrado: PATH, STATUS, contenido
 - **Detectar imports**: Si contiene `@path/to/file`, listar archivos importados
 
 ---
 
-## 📋 5. Project Rules (Equipo - Modular)
-
-**Descripción**: Reglas modulares del proyecto, organizadas por tema, con soporte de paths específicos.
-
-**Ubicación**: `./.claude/rules/*.md`
+### Project Rules (Equipo - Modular)
 
 **Qué mostrar**:
-- PATH del directorio `./.claude/rules/`
+- PATH del directorio
 - Listar TODOS los archivos `.md` recursivamente
-- Estructura de subdirectorios (ej: `frontend/`, `backend/`)
+- Estructura de subdirectorios
 - Para cada archivo:
   - PATH completo
   - Si tiene YAML frontmatter con `paths:`, mostrarlo
   - Contenido completo del archivo
   - Si es symlink, indicar a qué apunta y mostrar contenido del destino
 
-**Ejemplo de estructura**:
-```
-./.claude/rules/
-├── frontend/
-│   ├── react.md         (con paths: "src/**/*.tsx")
-│   └── styles.md        (con paths: "src/**/*.css")
-├── backend/
-│   ├── api.md           (con paths: "src/api/**/*.ts")
-│   └── database.md      (sin paths - aplica a todo)
-└── security.md          (sin paths - aplica a todo)
-```
-
 ---
 
-## 🔒 6. Project Local (Personal - No en Git)
-
-**Descripción**: Preferencias personales del proyecto actual (automáticamente gitignored).
-
-**Ubicación**: `./CLAUDE.local.md`
+### Project Local (Personal - No en Git)
 
 **Qué mostrar**:
 - PATH completo
@@ -135,29 +99,9 @@ paths:
 - Contenido completo
 - **Detectar imports**: Si contiene `@path/to/file`, listar archivos importados
 
-**Nota**: Este archivo NO se comparte con el equipo (está en .gitignore automáticamente).
-
 ---
 
-## 🤖 7. Auto Memory (Claude Auto-Guarda)
-
-**Descripción**: Notas que Claude guarda automáticamente mientras trabaja en el proyecto.
-
-**Ubicación**: `~/.claude/projects/<project>/memory/`
-
-**Identificar <project>**:
-- Si el proyecto es un repositorio git: usar la raíz del repo
-- Si no es git: usar el directorio de trabajo actual
-
-**Estructura**:
-```
-~/.claude/projects/<project>/memory/
-├── MEMORY.md          ← Solo primeras 200 líneas se cargan al inicio
-├── debugging.md       ← Topic files (se leen on-demand)
-├── patterns.md
-├── api-conventions.md
-└── ...
-```
+### Auto Memory (Claude Auto-Guarda)
 
 **Qué mostrar**:
 - PATH completo del directorio de auto memory
@@ -165,7 +109,6 @@ paths:
 - Para `MEMORY.md`:
   - Mostrar **SOLO las primeras 200 líneas** (resto no se carga en Claude)
   - Indicar cuántas líneas tiene en total
-  - Ejemplo: "MEMORY.md (412 líneas, solo primeras 200 cargadas)"
 - Para otros archivos (topic files):
   - Nombre y número de líneas
   - PATH completo

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -310,7 +310,8 @@ Docs: Ver opción "Documentación y Ayuda"
 ## 🔗 Recursos
 
 - **Repositorio**: https://github.com/joseguillermomoreu-gif/tlotp
-- **Documentación**: `docs/`
+- **Documentación oficial (live)**: `prompts/docs-sources.md`
+- **Documentación interna**: `docs/`
 - **Milestones**: `MILESTONES.md`
 - **Contribuir**: `CONTRIBUTING.md`
 


### PR DESCRIPTION
## Summary
- Nuevo fichero central `prompts/docs-sources.md` con índice de 7+ URLs oficiales
- Reemplazadas ~545 líneas de documentación hardcodeada por instrucciones de WebFetch
- Ficheros modificados: `info_claude.md`, `03-jerarquia-oficial.md`, `14-skills-cli-reference.md`, `04-backend-cli.md`, `15-module-post-install-rules.md`, `tlotp-main.md`
- URLs indexadas: memory, hooks-guide, agent-teams, skills, sub-agents, output-styles, vercel-labs/skills, wmedia.es

## Test plan
- [ ] Verificar que WebFetch a cada URL del índice devuelve contenido correcto
- [ ] Ejecutar Palantír inspección y verificar que obtiene jerarquía live
- [ ] Ejecutar Celebrimbor y verificar que operaciones CLI funcionan con docs live
- [ ] Verificar que el cheatsheet rápido del módulo 14 sigue siendo correcto

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)