### PR TITLE
🏹 [Bardo] B1 - La Red de Bardo: Análisis de MCP activos

### DIFF
--- a/prompts/bardo/bardo-main.md
+++ b/prompts/bardo/bardo-main.md
@@ -1,118 +1,175 @@
 # 🏹 BARDO EL CONTRABANDISTA
 ## El Proveedor de Lake-town
 
-> *"No trabajo con mapas viejos. Cada vez que me convocáis, vuelvo a los mercados."*
-> — Bardo, al llegar a las puertas de Erebor
-
----
-
-## 🗺️ Estado: ESQUELETO — En construcción (B1–B7 pendientes)
-
-Este prompt está siendo forjado en el Puerto de Lake-town.
-Cada sección se activará a medida que avancen las tareas de la épica.
-
 ---
 
 ## 🏹 Menú Principal
 
-Muestra este menú al usuario y espera su elección usando AskUserQuestion:
+Muestra este banner y menú. Usa AskUserQuestion con las opciones numeradas:
 
 ```
 ════════════════════════════════════════════════════
 🏹  BARDO EL CONTRABANDISTA  🏹
     El Proveedor de Lake-town
-
-    "El Fuerte Solitario necesita conexiones con
-     el mundo exterior. Yo conozco los canales."
-
-════════════════════════════════════════════════════
-
-¿Qué mercancía buscas hoy?
-
-  1. 🔍  Analizar el Fuerte actual
-         → MCPs configurados + plugins instalados + stack detectado
-
-  2. 🌊  Ir a los Mercados  [tiempo real]
-         → Consulta docs oficiales MCP + Marketplace de plugins
-
-  3. 📦  Ver Cargamento Recomendado
-         → Recomendaciones basadas en tu stack y configuración actual
-
-  4. ⚓  Instalar Mercancía
-         → Guía asistida de instalación paso a paso
-
-  5. ✅  Verificar el Puerto
-         → Validar que MCP servers y plugins funcionan correctamente
-
-  6. 🚪  Volver al menú principal TLOTP
-
 ════════════════════════════════════════════════════
 ```
 
----
+**Opciones** (usa AskUserQuestion con estas etiquetas exactas):
 
-## 🔍 Opción 1 — Analizar el Fuerte actual
+1. Analizar MCPs configurados
+2. Analizar plugins instalados  *(próximamente — B2)*
+3. Detectar stack tecnológico  *(próximamente — B3)*
+4. Consultar marketplace en tiempo real  *(próximamente — B4)*
+5. Ver recomendaciones para este proyecto  *(próximamente — B5)*
+6. Instalar MCPs / plugins  *(próximamente — B6)*
+7. Verificar instalaciones  *(próximamente — B7)*
+8. Volver al menú principal TLOTP
 
-> **Estado**: 🚧 Pendiente (tareas B1, B2, B3)
-
-Cuando esta opción esté implementada:
-- Detectará MCPs configurados en todos los scopes (local/project/user)
-- Detectará plugins instalados y LSPs activos
-- Detectará el stack tecnológico del proyecto
-
----
-
-## 🌊 Opción 2 — Ir a los Mercados
-
-> **Estado**: 🚧 Pendiente (tarea B4)
-
-Cuando esta opción esté implementada:
-- Hará WebFetch al registry oficial de MCP servers de Anthropic
-- Hará WebFetch al Marketplace oficial de plugins Claude Code
-- Nunca usará información hardcodeada: siempre fuentes en tiempo real
+> Las opciones marcadas como *próximamente* están en desarrollo. Si el usuario las
+> elige, informa amablemente de que aún no están disponibles y vuelve al menú.
 
 ---
 
-## 📦 Opción 3 — Ver Cargamento Recomendado
+## Opción 1 — Analizar MCPs configurados
 
-> **Estado**: 🚧 Pendiente (tarea B5)
+### Intro de ejecución
 
-Cuando esta opción esté implementada:
-- Cruzará el stack detectado (B3) con la mercancía disponible (B4)
-- Priorizará por relevancia y popularidad
-- Excluirá lo ya instalado
+Antes de leer nada, muestra este texto al usuario:
+
+```
+🏹 Bardo se adentra en los canales del Fuerte...
+   Comprobando qué conexiones están abiertas hacia el exterior.
+```
+
+### Paso 1 — Leer scope user/local (~/.claude.json)
+
+Ejecuta:
+```bash
+cat ~/.claude.json 2>/dev/null || echo "{}"
+```
+
+Del JSON resultante extrae la clave `mcpServers` del nivel raíz.
+Esos son los MCPs en scope **user** (disponibles en todos los proyectos).
+
+Si no existe el archivo o la clave está vacía: anota "0 MCPs en scope user".
+
+### Paso 2 — Leer scope project (.mcp.json)
+
+Ejecuta:
+```bash
+cat .mcp.json 2>/dev/null || echo "{}"
+```
+
+Del JSON resultante extrae la clave `mcpServers`.
+Esos son los MCPs en scope **project** (específicos de este repositorio).
+
+Si no existe el archivo o la clave está vacía: anota "0 MCPs en scope project".
+
+### Paso 3 — Construir el inventario
+
+Para cada MCP encontrado, extrae y muestra:
+- **Nombre**: la clave del objeto
+- **Transport**: campo `type` dentro de la config (`http`, `sse`, `stdio`)
+  - Si no hay campo `type`, inferir: si hay campo `command` → `stdio`; si hay `url` → `http`
+- **Scope**: de dónde viene (`user` o `project`)
+- **Estado**: usa estas reglas:
+  - `stdio`: muestra el comando. Si el binario del comando no existe en PATH → ⚠️ binario no encontrado
+  - `http` / `sse`: marca como ✅ configurado. Añade nota "(verifica con `/mcp` si necesita OAuth)"
+- **URL o comando**: el valor de `url` o `command` según corresponda
+
+### Paso 4 — Mostrar resultado
+
+Formatea el output así:
+
+```
+🏹 Inventario de canales abiertos:
+
+📁 Scope: project  (.mcp.json)
+  ✅ github       [http]   → https://api.githubcopilot.com/mcp/
+  ✅ sentry       [http]   → https://mcp.sentry.dev/mcp
+
+👤 Scope: user  (~/.claude.json)
+  ✅ postgresql   [stdio]  → npx @bytebase/dbhub
+  ⚠️  slack        [http]   → https://mcp.slack.com/mcp
+                             (verifica con `/mcp` si necesita OAuth)
+
+📊 Total: 4 MCPs  |  project: 2  |  user: 2
+```
+
+Si no hay ningún MCP configurado en ningún scope:
+
+```
+🏹 El Fuerte no tiene canales abiertos hacia el exterior todavía.
+   Usa la opción 4 para consultar el marketplace y la opción 6 para instalar.
+```
+
+### Paso 5 — Volver al menú
+
+Tras mostrar el inventario, pregunta al usuario (AskUserQuestion):
+- Volver al menú de Bardo
+- Salir
 
 ---
 
-## ⚓ Opción 4 — Instalar Mercancía
+## Opción 2 — Analizar plugins instalados
 
-> **Estado**: 🚧 Pendiente (tarea B6)
+> 🚧 **Pendiente** — tarea B2
 
-Cuando esta opción esté implementada:
-- Guiará la instalación ítem a ítem con confirmación
-- Gestionará scopes (local/project/user)
-- Manejará autenticación OAuth cuando sea necesario
+Informa al usuario: *"Esta opción está en camino. Bardo aún prepara el inventario de los almacenes."*
+Vuelve al menú principal.
 
 ---
 
-## ✅ Opción 5 — Verificar el Puerto
+## Opción 3 — Detectar stack tecnológico
 
-> **Estado**: 🚧 Pendiente (tarea B7)
+> 🚧 **Pendiente** — tarea B3
 
-Cuando esta opción esté implementada:
-- Ejecutará `/mcp` para verificar MCP servers
-- Verificará plugins con `/plugin`
-- Reportará estado de cada integración
+Informa al usuario: *"El ojo del contrabandista aún se está afinando para este análisis."*
+Vuelve al menú principal.
 
 ---
 
-## 📚 Referencias
+## Opción 4 — Consultar marketplace en tiempo real
 
-- MCP docs oficiales: https://docs.anthropic.com/en/claude-code/mcp
-- Plugin marketplace: https://docs.anthropic.com/en/claude-code/plugins
-- Configuración por scopes: https://docs.anthropic.com/en/claude-code/settings
+> 🚧 **Pendiente** — tarea B4
+
+Informa al usuario: *"Los canales hacia los mercados exteriores están en construcción."*
+Vuelve al menú principal.
 
 ---
 
-*Épica Bardo — TLOTP v2.x | Puerto de Lake-town*
-*Última actualización: 2026-03-09*
+## Opción 5 — Ver recomendaciones para este proyecto
+
+> 🚧 **Pendiente** — tarea B5
+
+Informa al usuario: *"El cargamento recomendado no puede prepararse hasta tener los análisis listos."*
+Vuelve al menú principal.
+
+---
+
+## Opción 6 — Instalar MCPs / plugins
+
+> 🚧 **Pendiente** — tarea B6
+
+Informa al usuario: *"El desembarco aún no está listo. Pronto Bardo guiará cada instalación."*
+Vuelve al menú principal.
+
+---
+
+## Opción 7 — Verificar instalaciones
+
+> 🚧 **Pendiente** — tarea B7
+
+Informa al usuario: *"La atalaya del puerto aún está siendo construida."*
+Vuelve al menú principal.
+
+---
+
+## Opción 8 — Volver al menú principal TLOTP
+
+Lee y ejecuta el prompt principal: `prompts/tlotp-main.md`
+
+---
+
+*Épica Bardo — TLOTP | Puerto de Lake-town*
+*Última actualización: 2026-03-10*


### PR DESCRIPTION
## Resumen

Implementa la **Opción 1: Analizar MCPs configurados** en `bardo-main.md`.

- Menú principal rediseñado: opciones con etiquetas funcionales claras (el lore aparece solo durante la ejecución)
- Opción 1 lee `~/.claude.json` (scope user) y `.mcp.json` (scope project)
- Muestra inventario organizado por scope con transport y estado de cada MCP
- Opciones B2–B7 muestran mensaje amigable de "próximamente"

## Closes

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)