### PR TITLE
🏹 [Bardo] B2 - Los Almacenes de Lake-town: Análisis de plugins instalados

### DIFF
--- a/prompts/bardo/bardo-main.md
+++ b/prompts/bardo/bardo-main.md
@@ -17,7 +17,7 @@ Muestra este banner y menú. Usa AskUserQuestion con las opciones numeradas:
 **Opciones** (usa AskUserQuestion con estas etiquetas exactas):
 
 1. Analizar MCPs configurados
-2. Analizar plugins instalados  *(próximamente — B2)*
+2. Analizar plugins instalados
 3. Detectar stack tecnológico  *(próximamente — B3)*
 4. Consultar marketplace en tiempo real  *(próximamente — B4)*
 5. Ver recomendaciones para este proyecto  *(próximamente — B5)*
@@ -113,10 +113,91 @@ Tras mostrar el inventario, pregunta al usuario (AskUserQuestion):
 
 ## Opción 2 — Analizar plugins instalados
 
-> 🚧 **Pendiente** — tarea B2
+### Intro de ejecución
 
-Informa al usuario: *"Esta opción está en camino. Bardo aún prepara el inventario de los almacenes."*
-Vuelve al menú principal.
+Antes de leer nada, muestra este texto al usuario:
+
+```
+🏹 Bardo revisa los almacenes del Fuerte...
+   Contando el arsenal de herramientas instaladas.
+```
+
+### Paso 1 — Leer plugins en scope user
+
+Ejecuta:
+```bash
+ls ~/.claude/plugins/ 2>/dev/null || echo ""
+```
+
+Cada subdirectorio es un plugin instalado en scope **user**.
+
+### Paso 2 — Leer plugins en scope project
+
+Ejecuta:
+```bash
+ls .claude/plugins/ 2>/dev/null || echo ""
+```
+
+Cada subdirectorio es un plugin instalado en scope **project**.
+
+### Paso 3 — Leer estado (activo/desactivado) desde settings
+
+Ejecuta:
+```bash
+cat ~/.claude/settings.json 2>/dev/null || echo "{}"
+```
+
+Busca la clave `plugins` en el JSON. Cada entrada puede tener `"disabled": true`.
+Si un plugin aparece con `disabled: true` → estado ⏸️ desactivado.
+Si no aparece o `disabled` es false/ausente → estado ✅ activo.
+
+También ejecuta para el proyecto:
+```bash
+cat .claude/settings.json 2>/dev/null || echo "{}"
+```
+
+### Paso 4 — Clasificar tipo de plugin
+
+Para cada plugin encontrado, determina su tipo leyendo el nombre:
+- Termina en `-lsp` o contiene `lsp` → **LSP** (language server)
+- Nombres conocidos de integración (github, gitlab, slack, jira, linear, notion, figma, sentry, vercel, firebase, supabase, stripe, asana) → **integración**
+- Contiene `output-style` → **output**
+- Resto → **workflow**
+
+Si existe el archivo `~/.claude/plugins/<nombre>/plugin.json` léelo para obtener la descripción real.
+
+### Paso 5 — Mostrar resultado
+
+Formatea el output así:
+
+```
+🏹 Inventario de almacenes del Fuerte:
+
+👤 Scope: user  (~/.claude/plugins/)
+  ✅ php-lsp              [LSP]         → PHP Language Server
+  ✅ typescript-lsp       [LSP]         → TypeScript Language Server
+  ✅ github               [integración] → GitHub MCP bundled
+  ⏸️  explanatory-output-style  [output] → Desactivado
+
+📁 Scope: project  (.claude/plugins/)
+  ✅ sentry               [integración] → Error monitoring
+
+📊 Total: 5 plugins  |  4 activos  |  1 desactivado
+     LSPs: 2  |  Integraciones: 2  |  Output: 1
+```
+
+Si no hay ningún plugin instalado en ningún scope:
+
+```
+🏹 El Fuerte no tiene herramientas adicionales instaladas todavía.
+   Usa la opción 4 para explorar el marketplace y la opción 6 para instalar.
+```
+
+### Paso 6 — Volver al menú
+
+Tras mostrar el inventario, pregunta al usuario (AskUserQuestion):
+- Volver al menú de Bardo
+- Salir
 
 ---
 


### PR DESCRIPTION
## Resumen

Implementa la **Opción 2: Analizar plugins instalados** en `bardo-main.md`.

- Lee `~/.claude/plugins/` (scope user) y `.claude/plugins/` (scope project)
- Detecta estado activo/desactivado desde `settings.json`
- Clasifica por tipo: LSP, integración, output, workflow
- Lee `plugin.json` para descripciones reales cuando existe

## Closes

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)