### PR TITLE
🏹 [Bardo] B4 - Los Canales Ocultos: Consulta en tiempo real al marketplace

### DIFF
--- a/prompts/bardo/bardo-main.md
+++ b/prompts/bardo/bardo-main.md
@@ -19,7 +19,7 @@ Muestra este banner y menú. Usa AskUserQuestion con las opciones numeradas:
 1. Analizar MCPs configurados
 2. Analizar plugins instalados
 3. Detectar stack tecnológico
-4. Consultar marketplace en tiempo real  *(próximamente — B4)*
+4. Consultar marketplace en tiempo real
 5. Ver recomendaciones para este proyecto  *(próximamente — B5)*
 6. Instalar MCPs / plugins  *(próximamente — B6)*
 7. Verificar instalaciones  *(próximamente — B7)*
@@ -335,10 +335,86 @@ Tras mostrar el resultado, pregunta al usuario (AskUserQuestion):
 
 ## Opción 4 — Consultar marketplace en tiempo real
 
-> 🚧 **Pendiente** — tarea B4
+### Intro de ejecución
 
-Informa al usuario: *"Los canales hacia los mercados exteriores están en construcción."*
-Vuelve al menú principal.
+```
+🏹 Bardo parte por los canales ocultos hacia los mercados exteriores...
+   Trayendo información fresca. No confío en mapas viejos.
+```
+
+### Parte A — MCP Servers (WebFetch en tiempo real)
+
+Ejecuta un WebFetch a la documentación oficial de MCP:
+
+**URL**: `https://code.claude.com/docs/en/mcp.md`
+
+Del contenido obtenido, extrae y presenta:
+- La lista de MCP servers disponibles con sus nombres y descripciones
+- El comando de instalación para cada uno (`claude mcp add ...`)
+- Cualquier nota sobre autenticación requerida
+
+Muestra el resultado así:
+
+```
+🌊 MCP Servers disponibles (fuente oficial — tiempo real):
+
+  github        → Integración con GitHub: PRs, issues, code review
+                  claude mcp add --transport http github https://api.githubcopilot.com/mcp/
+
+  sentry        → Monitoreo de errores en producción
+                  claude mcp add --transport http sentry https://mcp.sentry.dev/mcp
+
+  postgresql    → Consultas directas a bases de datos PostgreSQL
+                  claude mcp add --transport stdio postgresql -- npx ...
+
+  [... lista completa según la página oficial ...]
+```
+
+Si el WebFetch falla (sin conexión o URL cambiada):
+
+```
+⚠️  Bardo no pudo llegar a los mercados exteriores.
+    Verifica tu conexión o consulta directamente:
+    → https://code.claude.com/docs/en/mcp.md
+```
+
+### Parte B — Plugins (marketplace interactivo)
+
+A diferencia de los MCPs, el catálogo de plugins **no tiene una página web estática**.
+El marketplace oficial de plugins vive dentro del propio Claude Code.
+
+Informa al usuario:
+
+```
+🧩 Plugins disponibles — Marketplace oficial de Claude Code:
+
+  El catálogo de plugins se navega directamente en Claude Code.
+  Para explorar y instalar plugins disponibles, ejecuta:
+
+    /plugin
+
+  Desde ahí puedes:
+    → Pestaña "Discover": ver todos los plugins del marketplace oficial
+    → Buscar por nombre o categoría
+    → Instalar con un solo comando eligiendo el scope
+
+  Plugins destacados del marketplace oficial:
+    • php-lsp, typescript-lsp, python-lsp... → Code intelligence (LSP)
+    • github, gitlab, slack, sentry...       → Integraciones externas
+    • commit-commands, pr-review-toolkit...  → Workflow de desarrollo
+```
+
+### Parte C — Guardar en memoria de sesión
+
+Guarda la lista de MCPs obtenida en memoria de sesión para que la Opción 5 pueda
+hacer el matching con el stack sin necesidad de repetir el WebFetch.
+
+### Paso final — Volver al menú
+
+Tras mostrar ambas partes, pregunta al usuario (AskUserQuestion):
+- Volver al menú de Bardo
+- Ver recomendaciones ahora (ir a Opción 5)
+- Salir
 
 ---
 


### PR DESCRIPTION
## Resumen

Implementa la **Opción 4: Consultar marketplace en tiempo real** en `bardo-main.md`.

- WebFetch a `https://code.claude.com/docs/en/mcp.md` para lista viva de MCP servers
- Fallback graceful si el fetch falla
- Para plugins: el marketplace oficial no tiene catálogo web estático — vive en el comando `/plugin` de Claude Code. Se guía al usuario a usarlo directamente
- Guarda MCPs en memoria de sesión para que la opción 5 los consuma sin repetir el fetch

## Nota de diseño

Tras investigar las URLs oficiales se confirmó que:
- **MCPs**: catálogo disponible vía WebFetch en `code.claude.com/docs/en/mcp.md`
- **Plugins**: no existe página web estática — el marketplace es interactivo dentro de Claude Code (`/plugin` → Discover)

## Closes

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)