### PR TITLE
feat(bardo): add specific WebFetch domains to PASO 1.5 permissions (#103)

### DIFF
--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -128,8 +128,10 @@ TLOTP necesita los siguientes permisos:
   🖥️  Bash     — Ejecutar comandos del sistema
                   (git, npm, npx, node -v, ls, mkdir, cat...)
 
-  🌐  WebFetch — Consultar documentación oficial de Claude Code
-                  (code.claude.com/docs)
+  🌐  WebFetch — Consultar documentación y marketplaces
+                  • code.claude.com/docs  (Palantír, Bardo)
+                  • api.anthropic.com     (Bardo — MCP registry)
+                  • skills.sh            (Celebrimbor — Skills marketplace)
 
   📝  Write    — Crear archivos de configuración
                   (.claude/, CLAUDE.md, rules, skills)
@@ -162,7 +164,10 @@ añade en tu settings.json:
 
 {
   "permissions": {
-    "allow": ["Bash", "WebFetch", "Write", "Edit", "Read"]
+    "allow": ["Bash", "Write", "Edit", "Read",
+              "WebFetch(code.claude.com)",
+              "WebFetch(api.anthropic.com)",
+              "WebFetch(skills.sh)"]
   }
 }
 


### PR DESCRIPTION
## Summary

- Expande el bloque visual de WebFetch en PASO 1.5 para mostrar los dominios específicos por épica (`code.claude.com`, `api.anthropic.com`, `skills.sh`)
- Actualiza el tip de `allowedTools` con los dominios concretos en lugar del genérico `WebFetch`

Closes #103