### PR TITLE
feat(palantir): add 'Volver al menú principal' option in Configurador and Hooks (#114)

### DIFF
--- a/prompts/palantir/sections/10-configurator-system.md
+++ b/prompts/palantir/sections/10-configurator-system.md
@@ -815,22 +815,29 @@ Después de mostrar la notificación de éxito, preguntar al usuario:
 Usar `AskUserQuestion`:
 ```
 header: "Continuar configurando"
-question: "¿Deseas añadir otra característica?"
+question: "¿Qué deseas hacer ahora?"
 multiSelect: false
 options:
-  1. label: "Sí, añadir otra"
+  1. label: "➕ Añadir otra característica"
      description: "Configurar una característica adicional"
 
-  2. label: "No, finalizar"
+  2. label: "🔙 Volver al menú de Palantír"
+     description: "Volver al menú principal para cambiar de modo"
+
+  3. label: "🚪 Finalizar"
      description: "Terminar y salir del Configurador"
 ```
 
-**Si elige "Sí, añadir otra"**:
+**Si elige "➕ Añadir otra característica"**:
 - **Volver al PASO 1** (Solicitar Característica)
 - Reiniciar el flujo completo del configurador
 - Mantener contexto de lo ya configurado
 
-**Si elige "No, finalizar"**:
+**Si elige "🔙 Volver al menú de Palantír"**:
+- Ejecutar el flujo de `00-menu-principal.md` desde el PASO 2 (menú)
+- Saltar el PASO 1.5 de permisos (ya pre-aprobados en esta sesión)
+
+**Si elige "🚪 Finalizar"**:
 - Mostrar mensaje final y terminar:
 
 ```markdown

--- a/prompts/palantir/sections/11-hooks-system.md
+++ b/prompts/palantir/sections/11-hooks-system.md
@@ -445,6 +445,37 @@ o al recargar la configuración.
 ═══════════════════════════════════════════════════════════
 ```
 
+**Usar AskUserQuestion** para navegar tras la creación:
+```json
+{
+  "questions": [
+    {
+      "header": "¿Qué hacemos ahora?",
+      "question": "Hook creado. ¿Qué deseas hacer a continuación?",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "➕ Crear otro hook",
+          "description": "Volver al asistente guiado de creación"
+        },
+        {
+          "label": "🔙 Volver al menú de Hooks",
+          "description": "Volver al submenu de hooks"
+        },
+        {
+          "label": "🏠 Volver al menú de Palantír",
+          "description": "Volver al menú principal para cambiar de modo"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Si elige "➕ Crear otro hook"**: Reiniciar desde el Paso 1 de Opción 2.
+**Si elige "🔙 Volver al menú de Hooks"**: Ejecutar el submenu inicial de este módulo.
+**Si elige "🏠 Volver al menú de Palantír"**: Ejecutar `00-menu-principal.md` desde PASO 2 (sin repetir permisos).
+
 ---
 
 ## 🤔 Opción 3: ¿Necesito un Hook o Algo Mejor?
@@ -538,6 +569,37 @@ Los MCP servers son la opción correcta porque:
 → Esto está fuera del alcance actual de Palantír
    Consulta: https://code.claude.com/docs/en/mcp
 ```
+
+Tras mostrar la recomendación, **usar AskUserQuestion**:
+```json
+{
+  "questions": [
+    {
+      "header": "¿Qué hacemos ahora?",
+      "question": "¿Qué deseas hacer con esta recomendación?",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "⚙️ Ir al Configurador",
+          "description": "Abrir el modo Configurar característica de Palantír"
+        },
+        {
+          "label": "🪝 Crear un hook",
+          "description": "Ir al asistente guiado de creación de hooks"
+        },
+        {
+          "label": "🔙 Volver al menú de Palantír",
+          "description": "Volver al menú principal para elegir otro modo"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Si elige "⚙️ Ir al Configurador"**: Ejecutar `10-configurator-system.md`.
+**Si elige "🪝 Crear un hook"**: Ir a Opción 2 de este módulo.
+**Si elige "🔙 Volver al menú de Palantír"**: Ejecutar `00-menu-principal.md` desde PASO 2 (sin repetir permisos).
 
 ---
 


### PR DESCRIPTION
## Summary

- Añade opción "🔙 Volver al menú de Palantír" en la pregunta final del Configurador (`10-configurator-system.md`)
- Añade navegación post-creación en Opción 2 de Hooks: crear otro / volver al menú hooks / volver a Palantír
- Añade navegación al final de Opción 3 (¿Necesito un hook?): ir al Configurador / crear hook / volver a Palantír
- En todos los casos el retorno al menú salta el PASO 1.5 de permisos (ya pre-aprobados)

Closes #114