### PR TITLE
feat(permisos): move permissions approval to each epic, remove global PASO 1.5 (#70)

### DIFF
--- a/prompts/celebrimbor/sections/02-menu-principal.md
+++ b/prompts/celebrimbor/sections/02-menu-principal.md
@@ -26,6 +26,39 @@ Mostrar menú interactivo con opciones disponibles según el entorno detectado.
 
 ---
 
+## 📋 Permisos de Celebrimbor
+
+**CRÍTICO**: Antes del menú, solicitar aprobación de permisos con `AskUserQuestion`:
+
+```
+⚒️ Permisos necesarios para Celebrimbor
+
+  🖥️  Bash     — Ejecutar comandos del sistema
+                  (npx skills-cli, nvm, node -v, ls, cat...)
+
+  📖  Read     — Leer skills instaladas y configuración
+                  (~/.claude/skills/, .claude/skills/, settings.json)
+
+  📝  Write    — Instalar nuevas skills y rules
+                  (~/.claude/skills/, .claude/rules/)
+
+  ✏️  Edit     — Actualizar y eliminar skills existentes
+
+  🌐  WebFetch — Consultar el marketplace de skills
+                  • skills.sh (Skills marketplace oficial)
+```
+
+**Opciones** (AskUserQuestion):
+1. **✅ Aprobar todos** (Recomendado) — Celebrimbor funcionará sin interrupciones
+2. **🔍 Revisar uno a uno** — Se pedirá permiso individual para cada acción
+3. **🚫 Cancelar** — Salir de Celebrimbor
+
+- **Aprobar todos**: Registrar permisos pre-aprobados. Continuar al menú.
+- **Revisar uno a uno**: Continuar al menú. Se pedirá confirmación en cada acción.
+- **Cancelar**: Mostrar despedida y terminar.
+
+---
+
 ## Opciones del Menú
 
 **IMPORTANTE**: NO repetir banner. Ir directo a opciones.

--- a/prompts/ents/sections/02-menu-principal.md
+++ b/prompts/ents/sections/02-menu-principal.md
@@ -8,6 +8,40 @@ Mostrar menú interactivo con las tres operaciones principales de los Ents.
 
 ---
 
+## 📋 Permisos de Ents
+
+**CRÍTICO**: Antes del menú, solicitar aprobación de permisos con `AskUserQuestion`:
+
+```
+🌳 Permisos necesarios para los Ents
+
+  🖥️  Bash     — Ejecutar comandos del sistema
+                  (ls, cat, git para leer/detectar workflows)
+
+  📖  Read     — Leer workflows y configuración del proyecto
+                  (.github/workflows/, package.json, composer.json...)
+
+  📝  Write    — Crear nuevos workflows de GitHub Actions
+                  (.github/workflows/)  ← Solo opciones 2 y 3
+
+  ✏️  Edit     — Modificar workflows existentes
+                  (.github/workflows/)  ← Solo opciones 2 y 3
+
+  🌐  WebFetch — Consultar documentación oficial en tiempo real
+                  • docs.github.com (GitHub Actions docs)
+```
+
+**Opciones** (AskUserQuestion):
+1. **✅ Aprobar todos** (Recomendado) — Los Ents trabajarán sin interrupciones
+2. **🔍 Revisar uno a uno** — Se pedirá permiso individual para cada acción
+3. **🚫 Cancelar** — Salir de Ents
+
+- **Aprobar todos**: Registrar permisos pre-aprobados. Continuar al menú.
+- **Revisar uno a uno**: Continuar al menú. Se pedirá confirmación en cada acción.
+- **Cancelar**: Mostrar despedida y terminar.
+
+---
+
 ## Menú de Selección
 
 **IMPORTANTE**: **DEBES usar la herramienta `AskUserQuestion`** (NO texto plano).

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -113,67 +113,6 @@ Combina siempre con tu configuración existente — nunca borra sin backup.
 
 **NO saltarse** este paso. **NO resumirlo**. Mostrarlo EXACTAMENTE como está en la sección "INICIO ÉPICO".
 
-### PASO 1.5: Solicitar Permisos (OBLIGATORIO)
-
-**CRÍTICO**: Inmediatamente después del banner, ANTES del menú, solicitar al usuario la aprobación de permisos que TLOTP necesita para funcionar sin interrupciones.
-
-**Mostrar al usuario**:
-
-```
-🔐 Permisos necesarios para TLOTP
-
-Para que las épicas funcionen sin interrupciones,
-TLOTP necesita los siguientes permisos:
-
-  🖥️  Bash     — Ejecutar comandos del sistema
-                  (git, npm, npx, node -v, ls, mkdir, cat...)
-
-  🌐  WebFetch — Consultar documentación y marketplaces
-                  • code.claude.com/docs  (Palantír, Bardo)
-                  • api.anthropic.com     (Bardo — MCP registry)
-                  • skills.sh            (Celebrimbor — Skills marketplace)
-
-  📝  Write    — Crear archivos de configuración
-                  (.claude/, CLAUDE.md, rules, skills)
-
-  ✏️  Edit     — Modificar archivos existentes de configuración
-
-  📖  Read     — Leer configuración actual del usuario
-```
-
-**Usar AskUserQuestion** con las opciones:
-
-1. **✅ Aprobar todos** (Recomendado) — TLOTP funcionará sin interrupciones
-2. **🔍 Revisar uno a uno** — Se pedirá permiso individual para cada acción
-3. **🚫 Cancelar** — Salir de TLOTP
-
-**Comportamiento según respuesta**:
-
-- **Aprobar todos**: Registrar internamente que los permisos fueron pre-aprobados. Continuar con PASO 2 (menú). Todas las épicas asumen permisos concedidos y ejecutan sin interrupciones.
-- **Revisar uno a uno**: Continuar con PASO 2 (menú). Las épicas pedirán confirmación antes de cada acción que requiera estos permisos (comportamiento por defecto de Claude Code).
-- **Cancelar**: Mostrar mensaje de despedida y terminar.
-
-**NOTA IMPORTANTE**: Este paso NO cambia los permisos técnicos de Claude Code (esos los gestiona el usuario en su configuración de allowedTools). Lo que hace es **informar al usuario** de qué va a necesitar TLOTP, para que pueda:
-1. Pre-aprobar las acciones cuando Claude Code se las pida
-2. O configurar `allowedTools` en su `settings.json` si prefiere no ver prompts de permiso
-
-**Referencia para el usuario avanzado** (mostrar solo si elige "Revisar uno a uno"):
-```
-💡 Tip: Si quieres evitar prompts de permiso permanentemente,
-añade en tu settings.json:
-
-{
-  "permissions": {
-    "allow": ["Bash", "Write", "Edit", "Read",
-              "WebFetch(code.claude.com)",
-              "WebFetch(api.anthropic.com)",
-              "WebFetch(skills.sh)"]
-  }
-}
-
-Más info: https://code.claude.com/docs/en/permissions
-```
-
 ### PASO 2: Menú de Selección
 
 Después del banner y la lista de épicas, usar **AskUserQuestion** para mostrar el menú de forma elegante.


### PR DESCRIPTION
## Summary

- Añade paso de permisos con `AskUserQuestion` en **Celebrimbor** (`02-menu-principal.md`) — permisos específicos: Bash, Read, Write, Edit, WebFetch(skills.sh)
- Añade paso de permisos con `AskUserQuestion` en **Ents** (`02-menu-principal.md`) — permisos específicos: Bash, Read, Write/Edit (solo modos 2 y 3), WebFetch(docs.github.com)
- **Elimina el PASO 1.5 global** de `tlotp-main.md` — cada épica ya gestiona sus propios permisos

### Estado final por épica
| Épica | Permisos propios |
|-------|-----------------|
| 🔮 Palantír | ✅ PASO 1.5 en `00-menu-principal.md` |
| 🏹 Bardo | ✅ PASO 1.5 en `bardo-main.md` |
| ⚒️ Celebrimbor | ✅ añadido en `02-menu-principal.md` |
| 🌳 Ents | ✅ añadido en `02-menu-principal.md` |

Closes #70