### PR TITLE
feat(ci): add automatic semantic versioning on merge to master (#44)

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,101 @@
+name: 🏹 SemVer - El Heraldo Automático
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  semver:
+    name: Bump versión semántica
+    runs-on: ubuntu-latest
+    # Evitar loop infinito: no ejecutar en commits del propio workflow
+    if: "!contains(github.event.head_commit.message, 'chore: bump version')"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Obtener último tag
+        id: last_tag
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=$LAST_TAG" >> $GITHUB_OUTPUT
+          echo "Último tag: $LAST_TAG"
+
+      - name: Analizar commits y determinar bump
+        id: bump
+        run: |
+          LAST_TAG="${{ steps.last_tag.outputs.tag }}"
+          COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
+
+          echo "Commits desde $LAST_TAG:"
+          echo "$COMMITS"
+
+          BUMP="none"
+
+          if echo "$COMMITS" | grep -qE "^feat!:|BREAKING CHANGE"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
+            BUMP="minor"
+          elif echo "$COMMITS" | grep -qE "^fix(\(.+\))?:"; then
+            BUMP="patch"
+          fi
+
+          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+          echo "Tipo de bump: $BUMP"
+
+      - name: Calcular nueva versión
+        id: version
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          LAST_TAG="${{ steps.last_tag.outputs.tag }}"
+          VERSION="${LAST_TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          case "${{ steps.bump.outputs.bump }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Nueva versión: $NEW_VERSION"
+
+      - name: Actualizar VERSION.md
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          TODAY=$(date +%Y-%m-%d)
+
+          sed -i "s/\*\*TLOTP v[0-9]*\.[0-9]*\.[0-9]*\*\*/**TLOTP ${NEW_VERSION}**/" prompts/VERSION.md
+          sed -i "s/\*\*Fecha release\*\*: [0-9-]*/\*\*Fecha release\*\*: ${TODAY}/" prompts/VERSION.md
+
+          echo "VERSION.md actualizado a ${NEW_VERSION}"
+
+      - name: Commit, tag y push
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add prompts/VERSION.md
+          git commit -m "chore: bump version to ${NEW_VERSION}"
+          git tag "${NEW_VERSION}"
+          git push origin master
+          git push origin "${NEW_VERSION}"
+          echo "✅ Versión ${NEW_VERSION} publicada"
+
+      - name: Sin cambios que versionar
+        if: steps.bump.outputs.bump == 'none'
+        run: |
+          echo "ℹ️  No se detectaron commits feat/fix desde ${{ steps.last_tag.outputs.tag }}"
+          echo "   Solo docs, chore, refactor u otros — no se bumpa la versión"


### PR DESCRIPTION
## Summary

Nuevo workflow `semver.yml` que automatiza el versionado semántico al mergear a `master`.

### Flujo resultante
1. Merge develop → master (manual, como siempre)
2. `semver.yml` analiza commits desde el último tag, determina el bump y actualiza `VERSION.md` + crea tag automáticamente
3. `release.yml` detecta el nuevo tag y publica el GitHub Release

### Lógica de bump
| Commit | Bump |
|--------|------|
| `feat!:` o `BREAKING CHANGE` | MAJOR |
| `feat:` | MINOR |
| `fix:` | PATCH |
| `docs:`, `chore:`, `refactor:`... | Sin bump |

### Protecciones
- Guard `if: !contains(...)` para evitar loop infinito con el commit de bump
- Si no hay commits feat/fix desde el último tag: no bumpa, solo informa

Closes #44