### PR TITLE
fix(ci): remove direct push to protected master in semver workflow

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -70,29 +70,15 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "Nueva versión: $NEW_VERSION"
 
-      - name: Actualizar VERSION.md
-        if: steps.bump.outputs.bump != 'none'
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-          TODAY=$(date +%Y-%m-%d)
-
-          sed -i "s/\*\*TLOTP v[0-9]*\.[0-9]*\.[0-9]*\*\*/**TLOTP ${NEW_VERSION}**/" prompts/VERSION.md
-          sed -i "s/\*\*Fecha release\*\*: [0-9-]*/\*\*Fecha release\*\*: ${TODAY}/" prompts/VERSION.md
-
-          echo "VERSION.md actualizado a ${NEW_VERSION}"
-
-      - name: Commit, tag y push
+      - name: Crear tag
         if: steps.bump.outputs.bump != 'none'
         run: |
           NEW_VERSION="${{ steps.version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add prompts/VERSION.md
-          git commit -m "chore: bump version to ${NEW_VERSION}"
           git tag "${NEW_VERSION}"
-          git push origin master
           git push origin "${NEW_VERSION}"
-          echo "✅ Versión ${NEW_VERSION} publicada"
+          echo "✅ Tag ${NEW_VERSION} publicado"
 
       - name: Sin cambios que versionar
         if: steps.bump.outputs.bump == 'none'


### PR DESCRIPTION
## Summary

Corrige el workflow `semver.yml`: master está protegida y no permite push directo.
El workflow ahora solo crea y pushea el tag, sin intentar modificar master directamente.

Al mergear esta PR, el workflow se disparará y creará el tag `v3.8.0` automáticamente.