### PR TITLE
fix(aragorn): bring AR3-AR6 modules to develop (missed merge)

### DIFF
--- a/prompts/aragorn/ar3-buscar-agentes.md
+++ b/prompts/aragorn/ar3-buscar-agentes.md
@@ -1,0 +1,138 @@
+# 👑 AR3 - Los Mercados de las Tierras Libres: Buscar Agentes
+
+## Intro de ejecución
+
+```
+👑 Aragorn parte hacia los mercados de las Tierras Libres...
+   VoltAgent y aitmpl.com guardan ejércitos enteros esperando ser reclutados.
+   Consultando fuentes en tiempo real.
+```
+
+---
+
+## Paso 1 — Preguntar qué busca el usuario
+
+**Usar AskUserQuestion**:
+
+```
+🔍 BUSCAR AGENTES EN MARKETPLACES
+
+¿Cómo quieres buscar?
+```
+
+Opciones:
+1. **Por categoría** — código, testing, devops, seguridad, base de datos...
+2. **Por tecnología** — PHP, TypeScript, Python, Go, Rust...
+3. **Por palabra clave** — búsqueda libre
+4. **Ver todos los disponibles** — listar catálogo completo
+5. **🔙 Volver al menú de Aragorn**
+
+---
+
+## Paso 2 — Consultar VoltAgent (WebFetch)
+
+Consultar el repositorio oficial de VoltAgent en tiempo real:
+
+```
+WebFetch: https://raw.githubusercontent.com/VoltAgent/awesome-claude-code-subagents/main/README.md
+```
+
+Del contenido extraer:
+- Lista de agentes por categoría
+- Nombre, descripción y enlace de cada agente
+
+Si el WebFetch falla:
+```
+⚠️  No se pudo contactar con VoltAgent.
+    URL alternativa: https://github.com/VoltAgent/awesome-claude-code-subagents
+```
+
+### Categorías de VoltAgent
+
+| Categoría | Descripción |
+|-----------|-------------|
+| code-quality | Linters, reviewers, refactoring |
+| testing | Test generators, E2E, coverage |
+| documentation | Doc writers, README generators |
+| devops | CI/CD, deploy, monitoring |
+| security | Audit, SAST, vulnerability scan |
+| database | Migrations, queries, schema |
+| frontend | UI, components, accessibility |
+| backend | APIs, services, architecture |
+| meta-orchestration | Coordinadores de agentes |
+| specialized | Dominio específico |
+
+---
+
+## Paso 3 — Consultar aitmpl.com (WebFetch)
+
+```
+WebFetch: https://aitmpl.com/agents
+```
+
+Extraer agentes disponibles con nombre y descripción.
+
+Si el WebFetch falla, informar con URL alternativa: `https://aitmpl.com`
+
+---
+
+## Paso 4 — Filtrar según búsqueda
+
+### Si busca por categoría
+Mostrar solo agentes de la categoría seleccionada de ambos marketplaces.
+
+### Si busca por tecnología
+Filtrar agentes cuyo nombre o descripción mencione la tecnología (PHP, Symfony, TypeScript, React, Python, etc.).
+
+### Si busca por keyword
+Filtrar agentes cuyo nombre o descripción contenga la palabra clave.
+
+### Si quiere ver todos
+Mostrar listado completo agrupado por marketplace y categoría.
+
+---
+
+## Paso 5 — Mostrar resultados
+
+```
+🔍 Resultados para "php testing"
+══════════════════════════════════════════════════════
+
+VoltAgent (2 encontrados):
+──────────────────────────
+  1. phpunit-generator
+     📝 Genera tests PHPUnit con mocks y fixtures para clases PHP
+     🔧 Tools: Read, Write, Bash
+     📦 VoltAgent / 02-testing
+
+  2. symfony-test-writer
+     📝 Tests de integración para bundles Symfony con Fixtures y Faker
+     🔧 Tools: Read, Write, Bash, Grep
+     📦 VoltAgent / 02-testing
+
+aitmpl.com (1 encontrado):
+──────────────────────────
+  1. behat-scenario-writer
+     📝 Escribe escenarios Behat BDD desde criterios de aceptación
+     🔧 Tools: Read, Write
+     📦 aitmpl.com / agents
+
+══════════════════════════════════════════════════════
+📊 Total: 3 agentes encontrados
+```
+
+Si no hay resultados:
+```
+👑 Los mercados no tienen guerreros con ese perfil todavía.
+   Prueba con otra búsqueda o consulta el catálogo completo (opción 4).
+```
+
+---
+
+## Paso 6 — Acciones desde resultados
+
+Tras mostrar resultados, **usar AskUserQuestion**:
+- Instalar un agente de la lista (pedir cuál → ir a AR5)
+- Ver detalle de un agente (pedir cuál → WebFetch al README del agente)
+- Nueva búsqueda
+- Volver al menú de Aragorn

--- a/prompts/aragorn/ar4-recomendaciones.md
+++ b/prompts/aragorn/ar4-recomendaciones.md
@@ -1,0 +1,140 @@
+# 👑 AR4 - La Visión del Palantír Real: Motor de Recomendaciones
+
+## Intro de ejecución
+
+```
+👑 Aragorn consulta el Palantír del Rey...
+   Viendo el stack del Fuerte y los guerreros que mejor lo servirían.
+   Analizando el proyecto y consultando marketplaces.
+```
+
+---
+
+## Paso 1 — Detectar stack tecnológico
+
+Ejecutar para detectar qué tecnologías usa el proyecto:
+
+```bash
+ls composer.json package.json requirements.txt pyproject.toml go.mod Cargo.toml pom.xml build.gradle playwright.config.ts phpunit.xml behat.yml .github/workflows/ Dockerfile docker-compose.yml 2>/dev/null
+```
+
+Para cada fichero encontrado, leer y extraer tecnologías:
+
+**`composer.json`** → PHP
+```bash
+cat composer.json 2>/dev/null
+```
+- `symfony/` en require → **Symfony**
+- `laravel/` → **Laravel**
+- `doctrine/` → **Doctrine**
+- `phpunit/` → **PHPUnit**
+
+**`package.json`** → Node/JS/TS
+```bash
+cat package.json 2>/dev/null
+```
+- `typescript` → **TypeScript**
+- `react` → **React**
+- `next` → **Next.js**
+- `vue` → **Vue**
+- `@playwright/test` → **Playwright**
+
+**`requirements.txt` / `pyproject.toml`** → **Python**
+- `django` → **Django**
+- `fastapi` → **FastAPI**
+- `pytest` → **pytest**
+
+**`go.mod`** → **Go**
+**`Cargo.toml`** → **Rust**
+**`playwright.config.ts`** → **Playwright E2E**
+**`phpunit.xml`** → **PHPUnit**
+**`behat.yml`** → **Behat BDD**
+**`.github/workflows/`** → **GitHub Actions**
+
+---
+
+## Paso 2 — Consultar marketplaces (WebFetch)
+
+Reutilizar datos de sesión si ya se consultaron en AR3.
+Si no, hacer WebFetch a:
+```
+WebFetch: https://raw.githubusercontent.com/VoltAgent/awesome-claude-code-subagents/main/README.md
+```
+
+---
+
+## Paso 3 — Matching stack → agentes
+
+Para cada tecnología detectada, aplicar estas reglas de matching.
+**Excluir siempre** agentes ya instalados (comparando con AR1).
+
+| Stack detectado | Agentes recomendados | Por qué |
+|-----------------|----------------------|---------|
+| PHP / Symfony | `symfony-expert`, `php-refactor` | Experto en la arquitectura del proyecto |
+| PHP / Laravel | `laravel-expert` | Especialista en Laravel |
+| PHPUnit | `phpunit-generator` | Acelera la cobertura de tests |
+| Behat | `behat-scenario-writer` | Genera escenarios BDD |
+| TypeScript | `typescript-expert`, `type-checker` | Mejora tipado y refactor |
+| React | `react-component-generator` | Genera componentes con buenas prácticas |
+| Next.js | `nextjs-expert` | Optimizaciones y patrones Next.js |
+| Playwright | `playwright-test-writer` | Genera E2E tests automáticamente |
+| Python | `python-expert` | Mejoras de código Python |
+| Django | `django-expert` | Patrones y optimizaciones Django |
+| FastAPI | `fastapi-expert` | APIs rápidas con FastAPI |
+| GitHub Actions | `github-actions-optimizer` | Optimiza workflows CI/CD |
+| Docker | `dockerfile-optimizer` | Mejora Dockerfiles y compose |
+| Go | `go-expert` | Patrones idiomáticos de Go |
+| Rust | `rust-expert` | Ownership, lifetimes, patrones Rust |
+
+---
+
+## Paso 4 — Mostrar recomendaciones
+
+```
+💡 RECOMENDACIONES PARA TU PROYECTO
+══════════════════════════════════════════════════════
+
+Stack detectado: PHP/Symfony · PHPUnit · Playwright · GitHub Actions
+
+Agentes recomendados:
+──────────────────────────────────────────────────────
+
+  ⭐ symfony-expert  [VoltAgent / 08-backend]
+     🎯 Por qué: Tu proyecto usa Symfony — conoce su arquitectura a fondo
+     📝 Qué hace: Analiza services, repositorios, bundles y queries Doctrine
+     💡 Ejemplo: "Analiza UserRepository y sugiere mejoras de rendimiento"
+
+  ⭐ phpunit-generator  [VoltAgent / 02-testing]
+     🎯 Por qué: Tienes phpunit.xml — acelera la cobertura de tests
+     📝 Qué hace: Genera tests PHPUnit con mocks y fixtures automáticamente
+     💡 Ejemplo: "Genera tests para OrderService cubriendo casos edge"
+
+  ⭐ playwright-test-writer  [VoltAgent / 02-testing]
+     🎯 Por qué: Tienes Playwright configurado — genera E2E sin esfuerzo
+     📝 Qué hace: Escribe tests E2E siguiendo Page Object Model
+     💡 Ejemplo: "Genera el test E2E del flujo de checkout"
+
+  ⭐ github-actions-optimizer  [aitmpl.com]
+     🎯 Por qué: Tienes workflows en .github/workflows/
+     📝 Qué hace: Analiza y optimiza pipelines CI/CD
+     💡 Ejemplo: "Revisa mi CI y reduce el tiempo de ejecución"
+
+══════════════════════════════════════════════════════
+📊 4 recomendaciones  |  3 de VoltAgent  |  1 de aitmpl.com
+```
+
+Si no hay recomendaciones tras el matching:
+```
+👑 El Fuerte ya está bien equipado o usa tecnologías poco comunes.
+   Puedes explorar el marketplace manualmente (opción 2).
+```
+
+---
+
+## Paso 5 — Ofrecer instalación
+
+Tras mostrar recomendaciones, **usar AskUserQuestion**:
+- Instalar todos los recomendados (ir a AR5 con lista pre-cargada)
+- Seleccionar cuáles instalar (ir a AR5 con selección manual)
+- Volver al menú de Aragorn
+- Salir

--- a/prompts/aragorn/ar5-instalar-agente.md
+++ b/prompts/aragorn/ar5-instalar-agente.md
@@ -1,0 +1,161 @@
+# 👑 AR5 - El Reclutamiento del Ejército: Instalar Agente
+
+## Intro de ejecución
+
+```
+👑 Aragorn prepara los contratos de reclutamiento...
+   Cada guerrero que se une al ejército debe ser verificado antes de jurar lealtad.
+```
+
+---
+
+## Paso 1 — Obtener agente a instalar
+
+Si vienes de AR3 o AR4 con un agente pre-seleccionado: usar ese agente directamente.
+
+Si el usuario llega directo desde el menú, preguntar (AskUserQuestion):
+- Ver recomendaciones primero (ir a AR4)
+- Buscar en marketplaces (ir a AR3)
+- Escribir el nombre del agente manualmente
+
+---
+
+## Paso 2 — Preguntar scope
+
+**Usar AskUserQuestion**:
+
+```
+⚔️  Reclutando: [nombre-del-agente]
+    Fuente: [VoltAgent / aitmpl.com]
+
+    📝 [descripción del agente]
+
+    ¿Dónde quieres instalarlo?
+```
+
+Opciones:
+- **🌍 Global** (`~/.claude/agents/`) — disponible en todos tus proyectos
+- **📁 Proyecto** (`.claude/agents/`) — solo en este proyecto
+
+---
+
+## Paso 3 — Descargar el agente
+
+### Desde VoltAgent (GitHub raw)
+
+Construir la URL del raw del fichero `.md`:
+```
+WebFetch: https://raw.githubusercontent.com/VoltAgent/awesome-claude-code-subagents/main/agents/[categoria]/[nombre].md
+```
+
+Si la URL exacta no se conoce, buscar en el README de VoltAgent la referencia al agente.
+
+### Desde aitmpl.com
+
+Intentar WebFetch al fichero del agente:
+```
+WebFetch: https://aitmpl.com/api/agents/[nombre]
+```
+
+O indicar al usuario el comando alternativo:
+```bash
+npx claude-code-templates@latest add agent [nombre]
+```
+
+---
+
+## Paso 4 — Mostrar preview y pedir confirmación
+
+Antes de escribir nada, mostrar:
+
+```
+📄 PREVIEW DEL AGENTE
+══════════════════════════════════════════════════════
+
+Nombre:    symfony-expert
+Destino:   ~/.claude/agents/symfony-expert.md
+Fuente:    VoltAgent / 08-backend
+
+--- Contenido del fichero ---
+---
+name: symfony-expert
+description: |
+  Experto en Symfony para análisis de bundles, services y Doctrine.
+tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+model: claude-sonnet-4-6
+---
+[contenido del fichero...]
+══════════════════════════════════════════════════════
+```
+
+**Usar AskUserQuestion**:
+- ✅ Instalar — escribir el fichero en el destino
+- ✏️ Ver fichero completo — mostrar todo el contenido antes de decidir
+- ❌ Cancelar
+
+---
+
+## Paso 5 — Verificar conflicto de nombre
+
+Antes de escribir, comprobar si ya existe un agente con el mismo nombre:
+
+```bash
+ls ~/.claude/agents/[nombre].md 2>/dev/null
+# o
+ls .claude/agents/[nombre].md 2>/dev/null
+```
+
+Si existe, informar y preguntar (AskUserQuestion):
+```
+⚠️  Ya existe un agente llamado "[nombre]"
+    Ubicación: ~/.claude/agents/[nombre].md
+
+¿Qué hacer?
+```
+- 🔄 Sobreescribir — instalar la versión del marketplace
+- 📋 Ver diferencias — mostrar ambos contenidos
+- ❌ Cancelar
+
+---
+
+## Paso 6 — Instalar el agente
+
+Crear el directorio si no existe:
+
+```bash
+mkdir -p ~/.claude/agents/
+# o
+mkdir -p .claude/agents/
+```
+
+Escribir el fichero `.md` con el contenido descargado usando la herramienta Write.
+
+---
+
+## Paso 7 — Confirmar instalación
+
+```
+✅ RECLUTAMIENTO COMPLETADO
+══════════════════════════════════════════════════════
+
+  symfony-expert instalado correctamente
+  📍 Ubicación: ~/.claude/agents/symfony-expert.md
+  🌍 Scope: Global (disponible en todos tus proyectos)
+
+  El agente estará disponible en tu próxima sesión de Claude Code.
+
+  💡 Cómo usarlo:
+     • Automático: Claude lo invocará cuando detecte tareas de Symfony
+     • Explícito: "@symfony-expert [tu tarea]"
+══════════════════════════════════════════════════════
+```
+
+**Usar AskUserQuestion**:
+- Verificar instalación (ir a AR6)
+- Instalar otro agente (volver al Paso 1)
+- Volver al menú de Aragorn
+- Salir

--- a/prompts/aragorn/ar6-verificar-agente.md
+++ b/prompts/aragorn/ar6-verificar-agente.md
@@ -1,0 +1,134 @@
+# 👑 AR6 - La Revista de las Tropas: Verificar Instalación
+
+## Intro de ejecución
+
+```
+👑 Aragorn pasa revista a las tropas recién reclutadas...
+   Un guerrero que no puede ser invocado no sirve al ejército.
+```
+
+---
+
+## Paso 1 — Identificar agente a verificar
+
+Si vienes de AR5 con un agente recién instalado: verificar ese agente.
+
+Si el usuario llega directo, preguntar (AskUserQuestion):
+- Qué agente quiere verificar (listar los instalados desde AR1)
+- Volver al menú de Aragorn
+
+---
+
+## Paso 2 — Comprobar existencia del fichero
+
+```bash
+ls ~/.claude/agents/[nombre].md 2>/dev/null || ls .claude/agents/[nombre].md 2>/dev/null || echo "NOT_FOUND"
+```
+
+Si no existe:
+```
+❌ El agente "[nombre]" no se encontró en ningún scope.
+   Verifica la instalación con la Opción 3 (Instalar agente).
+```
+
+---
+
+## Paso 3 — Leer y validar YAML frontmatter
+
+```bash
+cat ~/.claude/agents/[nombre].md 2>/dev/null
+```
+
+Validar campo a campo:
+
+| Campo | Validación |
+|-------|-----------|
+| `name` | Presente y es string no vacío |
+| `description` | Presente y tiene al menos 10 caracteres |
+| `tools` | Si presente, cada tool es válida (Read, Write, Bash, Grep, Glob, Edit, MultiEdit, NotebookRead, NotebookEdit, WebFetch, WebSearch, TodoRead, TodoWrite) |
+| `model` | Si presente, es un modelo Claude válido |
+| `permissionMode` | Si presente, es `default`, `acceptEdits` o `bypassPermissions` |
+| `maxTurns` | Si presente, es número entero positivo |
+
+---
+
+## Paso 4 — Mostrar informe de semáforos
+
+```
+✅ REVISTA DE TROPAS: symfony-expert
+══════════════════════════════════════════════════════
+
+📍 Ubicación: ~/.claude/agents/symfony-expert.md
+🌍 Scope: Global
+
+Verificación del fichero:
+  ✅ Fichero existe y es legible
+  ✅ YAML frontmatter válido (delimitadores --- correctos)
+  ✅ name: "symfony-expert" — presente y válido
+  ✅ description: presente (142 chars) — suficiente para invocación automática
+  ✅ tools: [Read, Write, Bash, Grep] — todas válidas
+  ✅ model: "claude-sonnet-4-6" — válido
+  ⚠️  maxTurns: no definido — usará límite por defecto (sin límite)
+  ℹ️  permissionMode: no definido — usará "default"
+
+Estado: ✅ Agente listo para ser invocado
+══════════════════════════════════════════════════════
+```
+
+### Semáforos
+
+| Símbolo | Significado |
+|---------|-------------|
+| ✅ | Campo presente y válido |
+| ⚠️ | Campo opcional no definido, se usará valor por defecto |
+| ℹ️ | Información adicional |
+| ❌ | Error — campo inválido o faltante obligatorio |
+
+---
+
+## Paso 5 — Guía de uso post-verificación
+
+Tras los semáforos, mostrar siempre:
+
+```
+📖 CÓMO INVOCAR symfony-expert
+──────────────────────────────────────────────────────
+
+  1. AUTOMÁTICO — Claude decide cuándo usarlo
+     Claude lee la description y lo invoca si la tarea encaja.
+     Ejemplo: "Analiza este UserRepository" → Claude invoca symfony-expert
+
+  2. EXPLÍCITO — Tú decides usarlo
+     "@symfony-expert [tu petición]"
+     Ejemplo: "@symfony-expert revisa el bundle de pagos y detecta issues"
+
+  3. SCOPE
+     Instalado en: ~/.claude/agents/ (Global)
+     Disponible en: todos tus proyectos Claude Code
+
+  💡 Consejo: Si Claude no lo invoca automáticamente cuando esperas,
+     revisa que la description sea suficientemente descriptiva sobre
+     cuándo debe activarse.
+```
+
+---
+
+## Paso 6 — Errores comunes y resolución
+
+Si hay ❌ en algún campo:
+
+| Error | Causa probable | Resolución |
+|-------|---------------|------------|
+| YAML inválido | Sintaxis incorrecta en frontmatter | Mostrar línea del error; ofrecer editar |
+| Tool desconocida | Nombre de tool no existe | Mostrar lista de tools válidas |
+| Model inválido | Nombre de modelo incorrecto | Sugerir `claude-sonnet-4-6` o `claude-opus-4-6` |
+| name vacío | Frontmatter incompleto | Usar nombre del fichero como fallback |
+
+---
+
+## Paso 7 — Volver al menú
+
+**Usar AskUserQuestion**:
+- Volver al menú de Aragorn
+- Listar todos los agentes (ir a AR1)
+- Salir


### PR DESCRIPTION
## Summary

- PR #131 (AR3-AR6) se mergeó accidentalmente contra `master` en lugar de `develop`
- Esto causó que `ar3-buscar-agentes.md`, `ar4-recomendaciones.md`, `ar5-instalar-agente.md` y `ar6-verificar-agente.md` no existieran en develop
- El CI detectó los links rotos en `aragorn-main.md` que referencia estos ficheros
- Cherry-pick del commit original `a32e7fc` a develop

## Test plan

- [ ] Verificar que los 4 ficheros AR3-AR6 existen en develop tras el merge
- [ ] CI debe pasar (links internos válidos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)