### PR TITLE
feat(tlotp): add lore, fix menu pagination and show intro (#147)

### DIFF
--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -116,11 +116,16 @@ Nunca actúa sin confirmación.
 
 🗺️ **Épicas Disponibles**
 
-⚔️ **🔮 Palantír** — La Piedra Vidente. Domina las configuraciones de tu reino. *(CLAUDE.md · settings.json · rules/ · hooks · MEMORY.md)*
-⚔️ **🏹 Bardo** — El Contrabandista. Comercia con MCPs y plugins desde la Ciudad de Valle. *(~/.claude.json · .mcp.json · plugins/ · settings.json)*
-⚔️ **⚒️ Celebrimbor** — El Maestro Herrero Élfico, forjador de los Anillos de Poder. Forja skills a medida. *(~/.claude/skills/ · .claude/skills/)*
-⚔️ **🌳 Ents** — Los Pastores del Fangorn. Custodian las ramas y optimizan tu CI/CD. *(.github/workflows/ · GitHub Actions)*
-⚔️ **👑 Aragorn** — El Rey de Gondor. Convoca y gestiona tu ejército de agentes. *(agents/ · commands/ · teams/)*
+⚔️ **🔮 Palantír** — La Piedra Vidente. Domina las configuraciones de tu reino.
+   *(CLAUDE.md · settings.json · rules/ · hooks · MEMORY.md)*
+⚔️ **🏹 Bardo** — El Contrabandista. Comercia con MCPs y plugins desde la Ciudad de Valle.
+   *(~/.claude.json · .mcp.json · plugins/ · settings.json)*
+⚔️ **⚒️ Celebrimbor** — El Maestro Herrero Élfico, forjador de los Anillos de Poder. Forja skills a medida.
+   *(~/.claude/skills/ · .claude/skills/)*
+⚔️ **🌳 Ents** — Los Pastores del Fangorn. Custodian las ramas y optimizan tu CI/CD.
+   *(.github/workflows/ · GitHub Actions)*
+⚔️ **👑 Aragorn** — El Rey de Gondor. Convoca y gestiona tu ejército de agentes.
+   *(agents/ · commands/ · teams/)*
 
 🚧 En forja: **⚡ Gandalf** — El Mago Blanco. Spec-Driven Development.
 🔒 En las sombras: **💍 Gollum** — El Companion de Testing.


### PR DESCRIPTION
## Summary

- **Lore intro**: Add PASO 2 (CRÍTICO) to force display of the lore text after OS detection — was being skipped before
- **Menu pagination**: Replace flat 8-option menu with 2-screen AskUserQuestion (limit 4 options):
  - Pantalla 1: 🔮 Palantír · 🏹 Bardo · ⚒️ Celebrimbor · ➕ Ver más
  - Pantalla 2: 🌳 Ents · 👑 Aragorn · 🚪 Salir · 🔙 Volver
- **LOTR lore**: Epic descriptions now have lore flavor in both intro list and menu options
- **Cleanup**: Remove redundant inline menu block and duplicate sections

## Test plan

- [ ] Lore text "Un prompt para dominarlos a todos" appears after OS detection
- [ ] Epic list shows LOTR descriptions (Piedra Vidente, Trovador, etc.)
- [ ] Menu Pantalla 1 shows 3 epics + "Ver más"
- [ ] "Ver más" shows Pantalla 2 with Ents + Aragorn + Salir + Volver
- [ ] All routing works correctly

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)