### PR TITLE
fix(ci): add timeout and concurrency to semver workflow

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -8,10 +8,15 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: semver-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   semver:
     name: Bump versión semántica
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Evitar loop infinito: no ejecutar en commits del propio workflow
     if: "!contains(github.event.head_commit.message, 'chore: bump version')"
 


### PR DESCRIPTION
## Summary

- Add `timeout-minutes: 10` to `semver` job to prevent hung pipeline runs
- Add `concurrency` group (`cancel-in-progress: false`) to avoid duplicate version bumps on rapid master pushes

## Closes

Closes #161
Closes #162

## Test plan

- [ ] Verify semver workflow runs correctly on next master push
- [ ] Verify concurrency group appears in GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)