### PR TITLE
fix(ci): pin actions by SHA and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Lint Markdown
-        uses: DavidAnson/markdownlint-cli2-action@v17
+        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17
         with:
           globs: "**/*.md"
           config: ".markdownlint.json"
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check @prompts/ references
         run: |
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check external links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >
             --verbose

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -21,7 +21,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'chore: bump version')"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Crear GitHub Release
         if: steps.bump.outputs.bump != 'none'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: "TLOTP ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to commit SHAs (supply chain security best practice)
- Add `.github/dependabot.yml` to automatically keep SHAs up-to-date weekly

## Actions pinned

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4 | `34e1148...` |
| `DavidAnson/markdownlint-cli2-action` | v17 | `db43aef...` |
| `lycheeverse/lychee-action` | v2 | `8646ba3...` |
| `softprops/action-gh-release` | v2 | `a06a81a...` |

## Closes

Closes #163
Closes #164

## Test plan

- [ ] CI passes on this PR
- [ ] Dependabot PRs appear after next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)