### PR TITLE
docs: update VERSION.md to v3.15.0

### DIFF
--- a/prompts/VERSION.md
+++ b/prompts/VERSION.md
@@ -6,9 +6,21 @@
 
 ## 📊 Versión Actual
 
-**TLOTP v3.13.0**
+**TLOTP v3.15.0**
+- **Fecha release**: 2026-03-14
+- **Nombre código**: "Guardians of the Branch" (Ents redesign + CI/CD hardening)
+
+---
+
+## 📦 Historial de Versiones
+
+### v3.14.0 — "The Voices in the Stone"
+- **Fecha release**: 2026-03-14
+- Menú principal TLOTP rediseñado (paginación 3 pantallas)
+
+### v3.13.0 — "The Voices in the Stone"
 - **Fecha release**: 2026-03-12
-- **Nombre código**: "The Voices in the Stone" (Palantír redesign + TLOTP lore)
+- Palantír redesign completo + narrativa lore TLOTP
 
 ---
 


### PR DESCRIPTION
## Descripción

Actualiza VERSION.md para reflejar la versión real del tag (v3.15.0).

La versión bumpeó a v3.15.0 en lugar de v3.14.0 porque ya existía ese tag de una release anterior del día.

## Tipo de cambio

- [x] `docs` — Documentación

## Issues relacionados

N/A