### PR TITLE
fix(ci): mover permissions a nivel job y añadir concurrency a backmerge

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -5,15 +5,18 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: backmerge-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   backmerge:
     name: Sincronizar master → develop
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     # Evitar loop: no ejecutar si el push viene de un backmerge previo
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ''
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: release-prep
   cancel-in-progress: false
@@ -27,6 +23,9 @@ jobs:
     name: Preparar release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -8,9 +8,6 @@ on:
       - 'prompts/**'
       - '.github/workflows/semver.yml'
 
-permissions:
-  contents: write
-
 concurrency:
   group: semver-${{ github.ref }}
   cancel-in-progress: false
@@ -20,6 +17,8 @@ jobs:
     name: Bump versión semántica
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     # Evitar loop infinito: no ejecutar en commits del propio workflow
     if: "!contains(github.event.head_commit.message, 'chore: bump version')"
 


### PR DESCRIPTION
## Summary

- **#193** — Permissions movidos de nivel workflow a nivel job en `semver.yml`, `backmerge.yml` y `release-prep.yml` (least privilege)
- **#194** — Añadido `concurrency` group a `backmerge.yml` con `cancel-in-progress: false` para evitar backmerges paralelos

## Test plan

- [ ] CI verde (markdownlint + links)
- [ ] Verificar que semver.yml sigue creando tags correctamente en el próximo push a master
- [ ] Verificar que backmerge.yml sigue creando PRs correctamente

Closes #193
Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)