### PR TITLE
feat(ci): usar WORKFLOW_TOKEN para que PRs del bot disparen CI

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Configurar git
         run: |
@@ -61,4 +61,4 @@ jobs:
           gh pr merge "$PR_NUMBER" --auto --merge
           echo "✅ Auto-merge activado en PR #${PR_NUMBER}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Obtener último tag
         id: last_tag
@@ -150,7 +150,7 @@ jobs:
             --title "$TITLE" \
             --body "$BODY"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Sin cambios que versionar
         if: steps.bump.outputs.bump == 'none'

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -118,12 +118,12 @@ Nunca actúa sin confirmación.
 
 ⚔️ **🔮 Palantír** — La Piedra Vidente. Domina las configuraciones de tu reino.
    *(CLAUDE.md · settings.json · rules/ · hooks · MEMORY.md)*
-⚔️ **🏹 Bardo** — El Contrabandista. Comercia con MCPs y plugins desde la Ciudad de Valle.
-   *(~/.claude.json · .mcp.json · plugins/ · settings.json)*
-⚔️ **⚒️ Celebrimbor** — El Maestro Herrero Élfico, forjador de los Anillos de Poder. Forja skills a medida.
-   *(~/.claude/skills/ · .claude/skills/)*
 ⚔️ **🌳 Ents** — Los Pastores del Fangorn. Custodian las ramas y optimizan tu CI/CD.
    *(.github/workflows/ · GitHub Actions)*
+⚔️ **⚒️ Celebrimbor** — El Maestro Herrero Élfico, forjador de los Anillos de Poder. Forja skills a medida.
+   *(~/.claude/skills/ · .claude/skills/)*
+⚔️ **🏹 Bardo** — El Contrabandista. Comercia con MCPs y plugins desde la Ciudad de Valle.
+   *(~/.claude.json · .mcp.json · plugins/ · settings.json)*
 ⚔️ **👑 Aragorn** — El Rey de Gondor. Convoca y gestiona tu ejército de agentes.
    *(agents/ · commands/ · teams/)*
 
@@ -151,7 +151,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
         "description": ""
       },
       {
-        "label": "🏹 Reunir monedas para Bardo",
+        "label": "🌳 Convocar la Asamblea de los Ents",
         "description": ""
       },
       {
@@ -181,7 +181,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
         "description": ""
       },
       {
-        "label": "🌳 Convocar la Asamblea de los Ents",
+        "label": "🏹 Reunir monedas para Bardo",
         "description": ""
       },
       {
@@ -211,7 +211,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
         "description": ""
       },
       {
-        "label": "📚 Documentación y Ayuda",
+        "label": "⚡ Consultar al Mago Blanco — Gandalf",
         "description": ""
       },
       {
@@ -229,17 +229,45 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
 
 **Routing**:
 - 🔮 Contemplar la Piedra Vidente → Cargar `@prompts/palantir/palantir-main.md`
-- 🏹 Reunir monedas para Bardo → Cargar `@prompts/bardo/bardo-main.md`
-- ⚒️ Acudir a la forja de Celebrimbor → Cargar `@prompts/celebrimbor/celebrimbor-main.md`
 - 🌳 Convocar la Asamblea de los Ents → Cargar `@prompts/ents/ents-main.md`
+- ⚒️ Acudir a la forja de Celebrimbor → Cargar `@prompts/celebrimbor/celebrimbor-main.md`
+- 🏹 Reunir monedas para Bardo → Cargar `@prompts/bardo/bardo-main.md`
 - 👑 Usar el cuerno de Gondor para convocar a Aragorn → Cargar `@prompts/aragorn/aragorn-main.md`
-- 📚 Documentación y Ayuda → Mostrar sección "Documentación y Ayuda" (ver más abajo)
+- ⚡ Consultar al Mago Blanco — Gandalf → Mostrar mensaje WIP (ver más abajo)
 - 🔙 Volver al inicio → Mostrar Pantalla 1
 - 🚪 Salir → Mensaje de despedida épico y terminar
 
 ### PASO 4: Loop Continuo
 
 **Loop continuo** hasta que el usuario elija Salir o seleccione una épica específica.
+
+---
+
+## ⚡ Contenido de "Consultar al Mago Blanco — Gandalf"
+
+**Si el usuario selecciona "⚡ Consultar al Mago Blanco — Gandalf"**, mostrar:
+
+```
+⚡ ...
+
+   "Un mago nunca llega tarde...
+    pero esta épica aún está siendo forjada
+    en las profundidades de Isengard."
+
+   ⚡ Gandalf — Spec-Driven Development
+
+   Cuando esté listo, el Mago Blanco te ayudará a diseñar
+   Software Design Documents de forma interactiva:
+   contexto, requisitos, arquitectura y decisiones técnicas
+   antes de escribir una sola línea de código.
+
+   🚧 Estado: En diseño activo
+   📋 Issue: github.com/joseguillermomoreu-gif/tlotp/issues/111
+
+⚡ ...
+```
+
+Tras mostrar el mensaje, volver al menú principal (Pantalla 1).
 
 ---
 


### PR DESCRIPTION
Cierra #204.

## Cambios
- `backmerge.yml`: checkout y `GH_TOKEN` usan `WORKFLOW_TOKEN` (PAT) → las PRs creadas por el bot dispararán CI normalmente
- `release-prep.yml`: ídem — checkout y `GH_TOKEN` en "Crear PR" usan `WORKFLOW_TOKEN`
- `prompts/tlotp-main.md`: reordenar menú principal (p1: Palantír+Ents · p2: Celebrimbor+Bardo · p3: Aragorn+Gandalf WIP)

## Pre-requisito
Antes de que el fix sea efectivo, Pépeton debe crear un **fine-grained PAT** con `contents: write` + `pull-requests: write` para este repo y añadirlo como secreto `WORKFLOW_TOKEN` en Settings → Secrets → Actions.