### PR TITLE
feat(celebrimbor): lore — peregrinaje a Eregion y banner de bienvenida

### DIFF
--- a/prompts/celebrimbor/celebrimbor-main.md
+++ b/prompts/celebrimbor/celebrimbor-main.md
@@ -1,6 +1,10 @@
-# ⚒️ Celebrimbor - El Forjador de Skills
+# ⚒️ Celebrimbor — La Forja de Eregion
 
-> *"En las fraguas de Eregion, cada herramienta se adapta a su artesano..."*
+> *"Los Gwaith-i-Mírdain no forjan por encargo. Forjan por trato. ¿Qué ofreces a cambio, viajero?"*
+
+Has llegado a Ost-in-Edhil, la ciudad de los herreros elfos de Eregion. Celebrimbor,
+señor de los Gwaith-i-Mírdain, te escucha. Como Annatar en su día, traes conocimiento
+y necesidad. Él pone la forja. Tú pones el propósito.
 
 ---
 

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -177,7 +177,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
     "multiSelect": false,
     "options": [
       {
-        "label": "⚒️ Acudir a la forja de Celebrimbor",
+        "label": "⚒️ Peregrinaje a Eregion, Celebrimbor nos espera",
         "description": ""
       },
       {
@@ -230,7 +230,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
 **Routing**:
 - 🔮 Contemplar la Piedra Vidente → Cargar `@prompts/palantir/palantir-main.md`
 - 🌳 Convocar la Asamblea de los Ents → Cargar `@prompts/ents/ents-main.md`
-- ⚒️ Acudir a la forja de Celebrimbor → Cargar `@prompts/celebrimbor/celebrimbor-main.md`
+- ⚒️ Peregrinaje a Eregion, Celebrimbor nos espera → Cargar `@prompts/celebrimbor/celebrimbor-main.md`
 - 🏹 Reunir monedas para Bardo → Cargar `@prompts/bardo/bardo-main.md`
 - 👑 Usar el cuerno de Gondor para convocar a Aragorn → Cargar `@prompts/aragorn/aragorn-main.md`
 - ⚡ Consultar al Mago Blanco — Gandalf → Mostrar mensaje WIP (ver más abajo)
@@ -377,7 +377,7 @@ Tras mostrar el bloque anterior, usar **AskUserQuestion**:
         "description": ""
       },
       {
-        "label": "⚒️ Ir a Celebrimbor",
+        "label": "⚒️ Peregrinaje a Eregion, Celebrimbor nos espera",
         "description": ""
       },
       {
@@ -395,7 +395,7 @@ Tras mostrar el bloque anterior, usar **AskUserQuestion**:
 
 **Routing**:
 - 🔮 Ir a Palantír → Cargar `@prompts/palantir/palantir-main.md`
-- ⚒️ Ir a Celebrimbor → Cargar `@prompts/celebrimbor/celebrimbor-main.md`
+- ⚒️ Peregrinaje a Eregion, Celebrimbor nos espera → Cargar `@prompts/celebrimbor/celebrimbor-main.md`
 - 🔙 Volver al menú principal → Mostrar Pantalla 1 del menú principal
 - 🚪 Salir → Mensaje de despedida épico y terminar
 


### PR DESCRIPTION
## Summary

- Renombra la opción de menú TLOTP (ambas variantes: usuario nuevo y usuario que vuelve) a `⚒️ Peregrinaje a Eregion, Celebrimbor nos espera`
- Nuevo banner en `celebrimbor-main.md` con narrativa del trato en Ost-in-Edhil/Eregion y referencia a los Gwaith-i-Mírdain

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)