### PR TITLE
feat(celebrimbor): rediseñar entry point — permisos y menú de 4 opciones

### DIFF
--- a/prompts/celebrimbor/celebrimbor-main.md
+++ b/prompts/celebrimbor/celebrimbor-main.md
@@ -59,27 +59,37 @@ Celebrimbor gestiona skills de Claude Code: busca e instala desde skills.sh, ana
 
 ## 🚀 Flujo de Ejecución
 
-### Paso 1: Detección de Entorno
+### Paso 1: Banner de Bienvenida + Detección de Entorno
 
-**Módulo**: `sections/01-detector-entorno.md`
+**Módulo**: `sections/02-menu-principal.md`
 
-1. Detectar Node.js, npm, npx
-2. Validar Node.js >=18
-3. Generar reporte visual
+1. Mostrar banner de Eregion (solo una vez)
+2. Ejecutar `sections/01-detector-entorno.md` — validar Node.js >=18
 
-### Paso 2: Verificación de Updates
+### Paso 2: Solicitud de Permisos
 
-Antes del menú, ejecutar silenciosamente:
+**Módulo**: `sections/02-menu-principal.md`
+
+AskUserQuestion con los permisos necesarios (Bash, Read, Write, Edit, WebFetch).
+
+### Paso 3: Verificación de Updates (silenciosa)
+
 ```bash
 npx skills check
 ```
-Si hay updates, indicarlo en el banner del menú.
+Si hay updates, avisarlo en el menú.
 
-**Ver**: `sections/11-module-update.md` (Paso 0)
-
-### Paso 3: Menú Principal
+### Paso 4: Menú Principal (loop)
 
 **Módulo**: `sections/02-menu-principal.md`
+
+```
+1. 🔍 Analizar skills instaladas y sugerir mejoras
+2. 📦 Buscar e instalar skills (skills.sh)
+3. 🔄 Actualizar skills (skills.sh)
+4. ✨ Crear una skill (asistido)
+5. 🚪 Salir de Eregion
+```
 
 ---
 

--- a/prompts/celebrimbor/sections/02-menu-principal.md
+++ b/prompts/celebrimbor/sections/02-menu-principal.md
@@ -1,8 +1,8 @@
-# 🎯 Menú Principal - Celebrimbor
+# ⚒️ Menú Principal — Celebrimbor
 
 ## Misión
 
-Mostrar menú interactivo con opciones disponibles según el entorno detectado.
+Gestionar el entry point de Celebrimbor: pedir permisos, mostrar el menú y enrutar al módulo correspondiente.
 
 **NOTA**: En todos los banners, reemplaza `{VERSION}` con la versión TLOTP cargada desde `@prompts/VERSION.md`.
 
@@ -11,228 +11,135 @@ Mostrar menú interactivo con opciones disponibles según el entorno detectado.
 ## Banner de Bienvenida (MOSTRAR SOLO UNA VEZ)
 
 ```
-═══════════════════════════════════════════════════════════════
-    🔮 Celebrimbor - El Forjador de Skills ⚒️
-═══════════════════════════════════════════════════════════════
+══════════════════════════════════════════════════════════════
+    ⚒️  CELEBRIMBOR — La Forja de Eregion
+══════════════════════════════════════════════════════════════
 
-    "Tres Anillos para los Reyes Elfos bajo el cielo..."
+    "Los Gwaith-i-Mírdain no forjan por encargo.
+     Forjan por trato. ¿Qué ofreces a cambio, viajero?"
 
-    TLOTP {VERSION} | Backend CLI ⚡
+    Has llegado a Ost-in-Edhil. Celebrimbor te escucha.
 
-═══════════════════════════════════════════════════════════════
+    TLOTP {VERSION} | Backend: npx skills ⚡
+
+══════════════════════════════════════════════════════════════
 ```
 
-**Después del banner**: Detector de entorno (módulo 01). Si todo OK, continuar al menú.
+**Después del banner**: Ejecutar detector de entorno (módulo `01-detector-entorno.md`).
+- ✅ Node.js >=18 detectado → continuar a permisos
+- ❌ Node.js no disponible o versión inferior → mostrar error y opciones de instalación
 
 ---
 
-## 📋 Permisos de Celebrimbor
+## 📋 Solicitud de Permisos
 
-**CRÍTICO**: Antes del menú, solicitar aprobación de permisos con `AskUserQuestion`:
+**CRÍTICO**: Antes del menú, solicitar aprobación con `AskUserQuestion`:
 
 ```
-⚒️ Permisos necesarios para Celebrimbor
+⚒️ Celebrimbor necesita los siguientes permisos
 
-  🖥️  Bash     — Ejecutar comandos del sistema
-                  (npx skills-cli, nvm, node -v, ls, cat...)
+  🖥️  Bash     — Ejecutar npx skills, node, ls, mkdir, rm...
 
-  📖  Read     — Leer skills instaladas y configuración
-                  (~/.claude/skills/, .claude/skills/, settings.json)
+  📖  Read     — Leer skills instaladas
+                  (~/.claude/skills/, .claude/skills/)
 
-  📝  Write    — Instalar nuevas skills y rules
-                  (~/.claude/skills/, .claude/rules/)
+  📝  Write    — Instalar y crear skills
+                  (~/.claude/skills/, .claude/skills/)
 
-  ✏️  Edit     — Actualizar y eliminar skills existentes
+  ✏️  Edit     — Actualizar skills existentes
 
-  🌐  WebFetch — Consultar el marketplace de skills
-                  • skills.sh (Skills marketplace oficial)
+  🌐  WebFetch — Consultar skills.sh y documentación oficial
+                  on-demand (nunca precargada)
+
+¿Apruebas los permisos de la Forja?
 ```
 
 **Opciones** (AskUserQuestion):
-1. **✅ Aprobar todos** (Recomendado) — Celebrimbor funcionará sin interrupciones
-2. **🔍 Revisar uno a uno** — Se pedirá permiso individual para cada acción
-3. **🚫 Cancelar** — Salir de Celebrimbor
+1. **✅ Aprobar todos** — Celebrimbor funcionará sin interrupciones
+2. **🚫 Cancelar** — Salir de Eregion
 
-- **Aprobar todos**: Registrar permisos pre-aprobados. Continuar al menú.
-- **Revisar uno a uno**: Continuar al menú. Se pedirá confirmación en cada acción.
-- **Cancelar**: Mostrar despedida y terminar.
+- **Aprobar todos**: Registrar permisos. Continuar al menú.
+- **Cancelar**: Mostrar despedida épica y terminar.
 
 ---
 
-## Opciones del Menú
+## Verificación de Updates (ANTES DEL MENÚ)
 
-**IMPORTANTE**: NO repetir banner. Ir directo a opciones.
-
-Operaciones:
-
-1. 🔍 Buscar Skills
-2. 📥 Instalar Skill
-3. 📋 Listar Skills Instaladas
-4. 🔄 Actualizar Skills
-5. 🗑️ Eliminar Skill
-6. 🤖 Modo Automático [🚧 WIP]
-7. ⚙️ Cambiar Backend [🚧 WIP]
-8. ℹ️ Ayuda
-9. 🚪 Salir
-
-Elige una opción [1-9]:
+Ejecutar silenciosamente:
+```bash
+npx skills check
 ```
 
-### Menú Limitado (Node.js < 18)
+Guardar resultado. Si hay updates disponibles, mostrarlo en el menú como aviso:
+```
+⚠️  Hay skills con actualizaciones disponibles → Opción 3
+```
+
+---
+
+## 🗡️ Menú Principal
+
+Mostrar con `AskUserQuestion`:
 
 ```
-⚠️ ADVERTENCIA: Node.js desactualizado detectado
+⚒️ La Forja de Eregion — ¿Cuál es tu trato, viajero?
 
-Tu Node.js:  v12.22.9  ❌
-Requerido:   v18.0.0+  ✅
+  {AVISO_UPDATES_SI_PROCEDE}
 
-┌─────────────────────────────────────────────────────────────┐
-│ 1. ⚡ Backend CLI (Node.js)                                 │
-│    • ❌ NO DISPONIBLE - Actualiza Node.js primero           │
-│    • Ver instrucciones de actualización                     │
-└─────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────┐
-│ 2. 📦 Backend Git (Universal)                               │
-│    • 🚧 WIP - Disponible en TLOTP v2.2.0                    │
-│    • Esta opción funcionará sin Node.js                     │
-└─────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────┐
-│ 3. 📖 Instrucciones de actualización de Node.js             │
-│ 4. ℹ️  Ayuda y Documentación                                │
-│ 5. 🚪 Salir                                                  │
-└─────────────────────────────────────────────────────────────┘
-
-Elige una opción [2-5]:
+  1. 🔍  Analizar skills instaladas y sugerir mejoras
+  2. 📦  Buscar e instalar skills (skills.sh)
+  3. 🔄  Actualizar skills (skills.sh)
+  4. ✨  Crear una skill (asistido)
+  5. 🚪  Salir de Eregion
 ```
+
+**Loop continuo**: al terminar cada módulo, volver a este menú (sin repetir banner ni permisos).
 
 ---
 
 ## Flujo de Navegación
 
-**Al seleccionar opción**:
+### Opción 1: Analizar skills y sugerir mejoras
+- Cargar módulo: `sections/07-module-search.md` *(análisis — pendiente rediseño #211)*
+- Inspeccionar skills instaladas en rutas oficiales
+- Comparar con doc oficial (WebFetch on-demand si no está en contexto)
+- Mostrar resumen con sugerencias
 
-### Opción 1: Buscar Skills ✅
-- **Cargar módulo**: `sections/07-module-search.md`
-- Solicitar query de búsqueda
-- Ejecutar búsqueda con backend
-- Mostrar resultados
-- Permitir acciones posteriores
+### Opción 2: Buscar e instalar skills (skills.sh)
+- Cargar módulo: `sections/08-module-install.md` *(pendiente rediseño #212)*
+- Buscar en skills.sh con `npx skills find <query>`
+- Instalar en estructura `<name>/SKILL.md`
+- Mostrar mensaje de lore épico al finalizar
 
-### Opción 2: Instalar Skill ✅
-- **Cargar módulo**: `sections/08-module-install.md`
-- Solicitar nombre de skill (o venir desde búsqueda)
-- Verificar si ya existe (duplicados)
-- Elegir ubicación (global/local)
-- Ejecutar instalación con backend
-- Configurar paths: si necesario
-- Verificar y confirmar instalación
+### Opción 3: Actualizar skills (skills.sh)
+- Cargar módulo: `sections/11-module-update.md` *(pendiente rediseño #213)*
+- Mostrar skills con updates disponibles
+- Confirmar y ejecutar `npx skills update`
 
-### Opción 3: Listar Skills ✅
-- **Cargar módulo**: `sections/09-module-list.md`
-- Analizar jerarquía oficial (4 ubicaciones)
-- Mostrar skills instaladas (global y local)
-- Ofrecer ver detalles completos
-- Permitir acciones (buscar, instalar, volver)
+### Opción 4: Crear una skill (asistido)
+- Módulo nuevo *(pendiente implementación #214)*
+- WebFetch on-demand a `https://code.claude.com/docs/en/skills`
+- Guiar al usuario paso a paso
+- Mostrar mensaje de lore épico al finalizar
 
-### Opción 4: Actualizar Skills ✅
-- **Cargar módulo**: `sections/11-module-update.md`
-- Verificar updates disponibles con `npx skills check`
-- Mostrar lista de skills con updates
-- Advertir que se actualizan TODAS (backend CLI)
-- Confirmación del usuario
-- Ejecutar `npx skills update`
-- Verificar resultado
-- Confirmar y mostrar qué se actualizó
-
-### Opción 5: Eliminar Skill ✅
-- **Cargar módulo**: `sections/10-module-remove.md`
-- Listar skills instaladas
-- Seleccionar skill a eliminar
-- Confirmación crítica (NO se puede deshacer)
-- Ejecutar con npx skills remove (o rm manual)
-- Verificar eliminación
-- Confirmar resultado
-
-### Opción 6: Modo Automático 🚧
-- **Estado**: WIP - Tarea #7
-- **Si el usuario la selecciona**, mostrar:
-
+### Opción 5: Salir de Eregion
 ```
-🚧 Modo Automático - En Desarrollo
+Los Gwaith-i-Mírdain guardan el fuego hasta tu regreso.
+Que tus skills sirvan bien en la Tierra Media, viajero.
 
-¿Qué hará esta funcionalidad?
-Detectará automáticamente el tipo de proyecto (React, Symfony,
-Playwright, Python, etc.) y te sugerirá/instalará las skills más
-relevantes sin tener que buscarlas manualmente una por una.
-
-Por ejemplo:
-- Proyecto Playwright → Instala skills: playwright, pom, typescript
-- Proyecto Symfony → Instala skills: php, symfony, doctrine, phpunit
-- Proyecto React → Instala skills: react, typescript, vite, testing-library
-
-Estado: 🚧 En desarrollo
-Disponible en: TLOTP v2.2.0
-
-Beneficio: Ahorra tiempo al configurar nuevos proyectos. Especialmente
-útil para stacks comunes donde ya sabemos qué skills necesitas.
-
-Presiona Enter para volver al menú...
+⚒️  Eregion cierra sus puertas. Por ahora.
 ```
-
-- Volver al menú
-
-### Opción 7: Cambiar Backend 🚧
-- **Estado**: WIP - v2.2.0 (Backend Git)
-- **Si el usuario la selecciona**, mostrar:
-
-```
-🚧 Cambiar Backend - En Desarrollo
-
-¿Qué hará esta funcionalidad?
-Te permitirá cambiar entre dos backends para gestionar skills:
-
-⚡ Backend CLI (Actual)
-   • Requiere: Node.js >= 18
-   • Ventaja: Rápido, selectivo, actualiza skills individuales
-   • Comando: npx skills [comando]
-
-📦 Backend Git (Futuro)
-   • Requiere: Solo git (universal)
-   • Ventaja: No depende de Node.js, funciona en cualquier entorno
-   • Método: Clona repos directamente desde GitHub
-
-Estado: 🚧 En desarrollo
-Disponible en: TLOTP v2.2.0
-
-Beneficio: Si no tienes Node.js o prefieres no instalarlo,
-podrás usar el backend Git y seguir gestionando skills.
-
-Presiona Enter para volver al menú...
-```
-
-- Volver al menú
-
-### Opción 8: Ayuda
-- Mostrar documentación de Celebrimbor
-- Links a ARCHITECTURE.md, README.md, docs/REQUISITOS.md
-
-### Opción 9: Salir
-- Mensaje de despedida épico
-- Finalizar
 
 ---
 
 ## Reglas de Ejecución
 
-1. **SIEMPRE mostrar banner de bienvenida**
-2. **Adaptar menú** según detección de entorno
-3. **Deshabilitar opciones** no disponibles (mostrar ❌)
-4. **Usar AskUserQuestion** para navegación elegante
-5. **Loop continuo** hasta que el usuario elija Salir
+1. **Banner y permisos**: solo al entrar, nunca en el loop del menú
+2. **AskUserQuestion**: para navegación elegante en todo momento
+3. **Loop continuo**: hasta que el usuario elija Salir
+4. **WebFetch on-demand**: nunca precargar docs oficiales
 
 ---
 
-**Módulo anterior**: 01-detector-entorno.md
-**Módulo siguiente**: 03-backend-cli.md
+**Módulo anterior**: `01-detector-entorno.md`
+**Módulos destino**: `07`, `08`, `11`, `14` (y nuevo módulo #214)


### PR DESCRIPTION
## Summary

- Reescribe `02-menu-principal.md` con el nuevo diseño:
  - Banner de Eregion/Gwaith-i-Mírdain (lore coherente con #209)
  - Solicitud de permisos con AskUserQuestion (patrón Palantír/Ents)
  - 4 opciones de menú + salir (sin opciones WIP)
  - Mensaje de despedida épico
- Actualiza `celebrimbor-main.md` con el nuevo flujo de ejecución de 4 pasos

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)