### PR TITLE
feat(celebrimbor): módulo buscar e instalar skills con estructura oficial

### DIFF
--- a/prompts/celebrimbor/sections/02-menu-principal.md
+++ b/prompts/celebrimbor/sections/02-menu-principal.md
@@ -106,7 +106,7 @@ Mostrar con `AskUserQuestion`:
 - Mostrar resumen con sugerencias
 
 ### Opción 2: Buscar e instalar skills (skills.sh)
-- Cargar módulo: `sections/08-module-install.md` *(pendiente rediseño #212)*
+- Cargar módulo: `sections/07-module-search.md` → continúa en `sections/08-module-install.md`
 - Buscar en skills.sh con `npx skills find <query>`
 - Instalar en estructura `<name>/SKILL.md`
 - Mostrar mensaje de lore épico al finalizar

--- a/prompts/celebrimbor/sections/07-module-search.md
+++ b/prompts/celebrimbor/sections/07-module-search.md
@@ -1,181 +1,72 @@
-# 🔍 Módulo de Búsqueda - Celebrimbor
+# 🔍 Módulo: Buscar Skills en skills.sh
 
 ## Misión
 
-Permitir al usuario buscar skills en el catálogo de skills.sh usando el backend seleccionado.
+Permitir al usuario buscar skills en el catálogo de skills.sh. Este módulo forma la primera parte de la opción "Buscar e instalar" del menú.
 
 ---
 
-## 🎯 Flujo de Búsqueda
+## Paso 0 — Mostrar skills ya instaladas
 
-### Paso 0: Analizar Skills Instaladas (PRE-BÚSQUEDA)
+Antes de pedir la búsqueda, mostrar un resumen de lo que el usuario ya tiene instalado (rutas oficiales):
 
-**IMPORTANTE**: Antes de buscar nuevas skills, mostrar qué tiene el usuario instalado.
-
-**Analizar jerarquía oficial de Claude Code**:
-
-Según documentación oficial, buscar skills en:
-
-1. **User Rules** (global): `~/.claude/rules/`
-2. **User Skills** (global): `~/.claude/skills/` (si existe)
-3. **Project Rules** (local): `./.claude/rules/`
-4. **Project Skills** (local): `./.claude/skills/` (si existe)
-
-**Comando**:
 ```bash
-# Listar skills globales
-ls -1 ~/.claude/skills/*.md 2>/dev/null
-ls -1 ~/.claude/rules/*.md 2>/dev/null
+# Nueva estructura (directorio)
+ls ~/.claude/skills/*/SKILL.md 2>/dev/null
+ls ./.claude/skills/*/SKILL.md 2>/dev/null
 
-# Listar skills locales (proyecto actual)
-ls -1 ./.claude/rules/*.md 2>/dev/null
-ls -1 ./.claude/skills/*.md 2>/dev/null
+# Estructura legacy (archivo plano)
+ls ~/.claude/skills/*.md 2>/dev/null | grep -v "/SKILL.md"
+ls ./.claude/skills/*.md 2>/dev/null | grep -v "/SKILL.md"
 ```
 
-**Parsear archivos**:
-- Extraer nombres de archivos (sin extensión .md)
-- Contar total de skills
-- Agrupar por ubicación (global/local)
-
-**Mostrar resumen al usuario**:
+Mostrar resumen compacto:
 ```
-═══════════════════════════════════════════════════════════════
-📦 Skills Instaladas Actualmente
-═══════════════════════════════════════════════════════════════
+📦 Skills instaladas actualmente:
+  🌍 Global (3): playwright-pom, typescript-utils, git-workflow
+  📂 Local (1):  php-pro
 
-Global (~/.claude/):
-  📁 skills/
-    • playwright-pom.md
-    • typescript-utils.md
-
-  📁 rules/
-    • llms.md
-    • git-workflow.md
-
-Proyecto actual (./.claude/):
-  📁 rules/
-    • php-symfony.md
-    • doctrine-best-practices.md
-
-═══════════════════════════════════════════════════════════════
-Total: 6 skills instaladas (4 globales, 2 locales)
-═══════════════════════════════════════════════════════════════
+Esta será la referencia para detectar duplicados.
 ```
 
-**Si NO hay skills instaladas**:
-```
-═══════════════════════════════════════════════════════════════
-📦 Skills Instaladas Actualmente
-═══════════════════════════════════════════════════════════════
-
-No se encontraron skills instaladas.
-
-Esta será tu primera skill 🎉
-
-═══════════════════════════════════════════════════════════════
-```
+Si no hay ninguna: `Esta será tu primera skill 🎉`
 
 ---
 
-### Paso 1: Solicitar Query (DESPUÉS de mostrar instaladas)
+## Paso 1 — Solicitar query
 
-**Mostrar prompt**:
 ```
-🔍 Buscar Nuevas Skills en skills.sh
+🔍 Buscar en skills.sh
 
 ¿Qué tipo de skill buscas?
-
-Ejemplos:
-  • playwright     - Skills de Playwright
-  • typescript     - Utilidades TypeScript
-  • react          - Componentes React
-  • php            - Herramientas PHP
-
-💡 Tip: Busca skills que complementen las que ya tienes
+Ejemplos: playwright, typescript, react, php, python, docker
 
 Búsqueda: _
 ```
 
-**Capturar input del usuario**
-
-**Validación**:
-- Mínimo 2 caracteres
-- Si vacío: volver al menú principal
-- Si "q" o "exit": volver al menú
+**Validación**: mínimo 2 caracteres. Si vacío o "q": volver al menú principal.
 
 ---
 
-### Paso 2: Ejecutar Búsqueda
-
-**Usar Backend CLI** (módulo 04-backend-cli.md):
+## Paso 2 — Ejecutar búsqueda
 
 ```bash
-npx skills search <query>
+npx skills find <query>
 ```
 
-**Ejemplo**:
-```bash
-npx skills search playwright
-```
-
-**Mostrar indicador de progreso**:
-```
-🔍 Buscando "playwright"...
-```
+Mostrar indicador: `🔍 Buscando "<query>"...`
 
 ---
 
-### Paso 3: Parsear Resultados
+## Paso 3 — Parsear y mostrar resultados
 
-**Output esperado de npx skills**:
-```
-🔍 Searching for "playwright"...
-
-Found 12 skills:
-
-  playwright-pom                    vercel-labs/skills
-  Page Object Model patterns for Playwright
-  1,523 installs
-
-  playwright-fixtures               playwright-community
-  Custom test fixtures for Playwright
-  892 installs
-
-  playwright-utils                  community/utils
-  Utilities for Playwright tests
-  456 installs
-```
-
-**Parsear**:
-- Extraer nombre de skill
-- Extraer autor/repositorio
-- Extraer descripción
-- Extraer número de instalaciones
-
-**Estructura de datos**:
-```yaml
-results:
-  - name: "playwright-pom"
-    author: "vercel-labs/skills"
-    description: "Page Object Model patterns for Playwright"
-    installs: 1523
-
-  - name: "playwright-fixtures"
-    author: "playwright-community"
-    description: "Custom test fixtures for Playwright"
-    installs: 892
-```
-
----
-
-### Paso 4: Formatear y Mostrar Resultados
-
-**Formato visual atractivo con detección de duplicados**:
+Para cada resultado, extraer: nombre, autor, descripción, instalaciones.
+Marcar con ✅ las que ya están instaladas (detectadas en Paso 0).
 
 ```
-═══════════════════════════════════════════════════════════════
-🔍 Resultados para "playwright" (12 skills encontradas)
-═══════════════════════════════════════════════════════════════
+══════════════════════════════════════════════════════════════
+🔍 Resultados para "playwright" (12 encontradas)
+══════════════════════════════════════════════════════════════
 
 1. playwright-pom ⭐ 1,523 installs
    📦 vercel-labs/skills
@@ -190,309 +81,58 @@ results:
    📦 community/utils
    📝 Utilities for Playwright tests
 
-4. playwright-api-testing ⭐ 234 installs
-   📦 api-testing/skills
-   📝 API testing helpers for Playwright
+... (mostrando 5 de 12)
 
-5. playwright-visual-regression ⭐ 189 installs
-   📦 visual-testing/skills
-   📝 Visual regression testing with Playwright
-
-... (mostrando 5 de 12 resultados)
-
-═══════════════════════════════════════════════════════════════
-💡 Nota: 1 skill ya instalada (marcada con ✅)
-═══════════════════════════════════════════════════════════════
-```
-
-**Opciones después de resultados**:
-
-```
-¿Qué deseas hacer?
-
-1. Ver todos los resultados (12)
-2. Instalar una skill (ir a módulo de instalación)
-3. Nueva búsqueda
-4. Volver al menú principal
-
-Elige [1-4]: _
+══════════════════════════════════════════════════════════════
 ```
 
 ---
 
-## 🎨 Manejo de Casos Especiales
+## Paso 4 — Opciones
 
-### Caso 1: No se encontraron skills
+Mostrar con `AskUserQuestion`:
 
-**Output de npx**:
 ```
-🔍 Searching for "nonexistent"...
+¿Qué deseas hacer?
 
-No skills found for "nonexistent"
+1. 📥 Instalar una skill de estos resultados
+2. 📄 Ver todos los resultados (12)
+3. 🔍 Nueva búsqueda
+4. 🔙 Volver al menú principal
 ```
 
-**Mostrar al usuario**:
+- **Instalar**: continuar a `08-module-install.md` pasando el contexto de resultados
+- **Ver todos**: mostrar lista completa y volver a opciones
+- **Nueva búsqueda**: repetir desde Paso 1
+- **Volver**: menú principal
+
+---
+
+## Casos especiales
+
+### Sin resultados
 ```
-═══════════════════════════════════════════════════════════════
-❌ No se encontraron skills para "nonexistent"
-═══════════════════════════════════════════════════════════════
+❌ No se encontraron skills para "<query>"
 
 Sugerencias:
   • Verifica la ortografía
-  • Prueba con términos más genéricos
-  • Busca en inglés (ej: "playwright" en vez de "pruebas")
-  • Explora el catálogo: https://skills.sh
+  • Prueba con términos más genéricos (ej: "test" en vez de "e2e-testing")
+  • Busca en inglés
+```
 
-¿Deseas hacer otra búsqueda? [s/N]: _
+### Error de red
+```
+⚠️ No se pudo conectar a skills.sh
+   Verifica tu conexión a internet e inténtalo de nuevo.
+```
+
+### npx no disponible
+```
+❌ npx no está disponible. Reinicia Celebrimbor para re-detectar el entorno.
 ```
 
 ---
 
-### Caso 2: Error de conexión
-
-**Error de npx**:
-```
-Error: Failed to fetch from skills.sh
-Network error: ENOTFOUND
-```
-
-**Mostrar al usuario**:
-```
-═══════════════════════════════════════════════════════════════
-⚠️ Error de Conexión
-═══════════════════════════════════════════════════════════════
-
-No se pudo conectar a skills.sh
-
-Posibles causas:
-  • Sin conexión a internet
-  • skills.sh temporalmente no disponible
-  • Firewall bloqueando la conexión
-
-Soluciones:
-  • Verifica tu conexión a internet
-  • Reintenta en unos momentos
-  • Usa Backend Git (sin conexión) en v2.2.0
-
-¿Reintentar búsqueda? [s/N]: _
-```
-
----
-
-### Caso 3: npx skills no disponible
-
-**Error**:
-```
-bash: npx: command not found
-```
-
-**Acción**:
-```
-═══════════════════════════════════════════════════════════════
-❌ Backend CLI No Disponible
-═══════════════════════════════════════════════════════════════
-
-npx no está disponible en tu sistema.
-
-Esto no debería ocurrir - la detección de entorno debió
-prevenir esto.
-
-Acciones:
-1. Reinstalar npm: https://nodejs.org
-2. Reiniciar Celebrimbor para re-detectar entorno
-3. Reportar bug: https://github.com/.../issues
-
-Volviendo al menú principal...
-```
-
----
-
-## 🔧 Características Avanzadas
-
-### Filtros de Búsqueda (Futuro v2.2)
-
-**Permitir filtros**:
-```
-🔍 Búsqueda Avanzada
-
-Query: playwright
-
-Filtros opcionales:
-  • Mínimo instalaciones: [100]
-  • Autor específico: [vercel-labs]
-  • Categoría: [testing]
-
-Buscar con filtros: _
-```
-
-### Cache de Resultados
-
-**Para búsquedas repetidas**:
-
-```yaml
-# ~/.celebrimbor/cache/search-results.yml
-
-searches:
-  - query: "playwright"
-    timestamp: "2026-02-15T10:30:00Z"
-    ttl: 3600  # 1 hora
-    results: [...]
-```
-
-**Lógica**:
-- Si búsqueda < 1 hora: usar cache
-- Si búsqueda > 1 hora: ejecutar de nuevo
-
-**Mostrar al usuario**:
-```
-🔍 Buscando "playwright"...
-✅ Usando resultados en cache (actualizado hace 15 min)
-
-(Para forzar nueva búsqueda, usa opción "Limpiar cache")
-```
-
----
-
-## 🔗 Integración con Otros Módulos
-
-### Con Módulo Listar (09)
-
-**IMPORTANTE**: Usar ANTES de solicitar query
-
-```python
-# PASO 0: Listar skills instaladas
-installed_skills = module_list.get_installed_skills()
-display_installed_summary(installed_skills)
-
-# PASO 1: Solicitar query
-query = ask_user("¿Qué skill buscas?")
-
-# PASO 2: Buscar
-results = backend.search(query)
-
-# PASO 3: Marcar duplicados
-for result in results:
-    if result.name in installed_skills:
-        result.already_installed = True
-```
-
-### Con Backend Selector (06)
-
-```python
-# Obtener backend seleccionado
-backend = selector.get_backend()
-
-# Ejecutar búsqueda usando backend
-results = backend.search(query)
-```
-
-### Con Backend CLI (04)
-
-```python
-# Backend CLI implementa search()
-def search(query, filters=None):
-    # Ejecutar: npx skills search {query}
-    output = bash("npx skills search " + query)
-
-    # Parsear output
-    results = parse_npx_output(output)
-
-    return results
-```
-
-### Con Menú Principal (02)
-
-```python
-# Usuario elige "1. Buscar skills"
-menu.option_1_selected():
-    # Cargar módulo de búsqueda
-    load_module("07-module-search.md")
-
-    # Ejecutar flujo de búsqueda
-    search_flow()
-```
-
-### Con Módulo Instalar (08) - Futuro
-
-```python
-# Después de mostrar resultados
-if user_selects("2. Instalar una skill"):
-    # Pasar resultados al módulo de instalación
-    install_module.run(selected_skill)
-```
-
----
-
-## 🎯 Reglas de Ejecución
-
-1. **SIEMPRE validar query** (mínimo 2 caracteres)
-2. **Mostrar indicador de progreso** mientras busca
-3. **Formatear resultados** de forma visual y clara
-4. **Limitar resultados iniciales** a 5-10 (ofrecer "ver más")
-5. **Capturar y manejar errores** gracefully
-6. **Permitir acciones posteriores** (instalar, nueva búsqueda, etc.)
-7. **Loop continuo** hasta que usuario decida salir
-
----
-
-## 📊 Ejemplo de Output Completo
-
-```
-═══════════════════════════════════════════════════════════════
-    🔮 Celebrimbor - Buscar Skills ⚒️
-═══════════════════════════════════════════════════════════════
-
-Backend: CLI ⚡ (Node.js v20.11.0)
-
-🔍 ¿Qué tipo de skill buscas?
-
-Búsqueda: playwright
-
-═══════════════════════════════════════════════════════════════
-
-🔍 Buscando "playwright"... ✓
-
-═══════════════════════════════════════════════════════════════
-🔍 Resultados para "playwright" (12 skills encontradas)
-═══════════════════════════════════════════════════════════════
-
-1. playwright-pom ⭐ 1,523 installs
-   📦 vercel-labs/skills
-   📝 Page Object Model patterns for Playwright
-
-2. playwright-fixtures ⭐ 892 installs
-   📦 playwright-community
-   📝 Custom test fixtures for Playwright
-
-3. playwright-utils ⭐ 456 installs
-   📦 community/utils
-   📝 Utilities for Playwright tests
-
-4. playwright-api-testing ⭐ 234 installs
-   📦 api-testing/skills
-   📝 API testing helpers for Playwright
-
-5. playwright-visual-regression ⭐ 189 installs
-   📦 visual-testing/skills
-   📝 Visual regression testing with Playwright
-
-... (mostrando 5 de 12)
-
-═══════════════════════════════════════════════════════════════
-
-¿Qué deseas hacer?
-
-1. Ver todos los resultados (12)
-2. Instalar una skill
-3. Nueva búsqueda
-4. Volver al menú principal
-
-Elige [1-4]: _
-```
-
----
-
-**Módulo anterior**: 06-backend-selector.md
-**Módulo siguiente**: 08-module-install.md (Tarea #4)
-**Integra con**: 02-menu-principal.md, 04-backend-cli.md, 06-backend-selector.md
-**Tarea**: #3 - Módulo Buscar (120 XP)
+**Módulo**: `07-module-search.md`
+**Invocado desde**: `02-menu-principal.md` (Opción 2)
+**Continúa en**: `08-module-install.md`

--- a/prompts/celebrimbor/sections/08-module-install.md
+++ b/prompts/celebrimbor/sections/08-module-install.md
@@ -1,562 +1,186 @@
-# 📥 Módulo de Instalación - Celebrimbor
+# 📥 Módulo: Instalar Skill
 
 ## Misión
 
-Instalar skills desde skills.sh con configuración automática y validación completa.
+Instalar una skill desde skills.sh en la estructura oficial de Claude Code (`<name>/SKILL.md`).
 
 ---
 
-## 🎯 Flujo de Instalación
+## Paso 1 — Seleccionar skill a instalar
 
-### Paso 1: Seleccionar Skill a Instalar
+**Dos formas de llegar aquí:**
 
-**Dos formas de llegar aquí**:
-
-#### Opción A: Desde Resultados de Búsqueda
-
-**Usuario ha buscado y ve resultados**:
-```
-🔍 Resultados para "playwright" (5 skills)
-
-1. playwright-pom ⭐ 1,523 installs
-2. playwright-fixtures ⭐ 892 installs
-3. playwright-utils ⭐ 456 installs
-
-¿Qué deseas hacer?
-1. Instalar una skill ← Usuario elige esto
-```
-
-**Preguntar**:
+### Desde resultados de búsqueda (07-module-search.md)
 ```
 ¿Qué skill quieres instalar?
-
-Introduce el número [1-3] o el nombre completo: _
+Introduce el número de la lista o el nombre completo: _
 ```
 
-**Validar**:
-- Si número: verificar rango (1-3)
-- Si nombre: verificar que existe en resultados
-
-#### Opción B: Instalación Directa
-
-**Usuario viene del menú principal** → "2. Instalar Skill"
-
-**Preguntar**:
+### Instalación directa desde menú
 ```
-📥 Instalar Skill
+📥 Instalar skill
 
-Introduce el nombre completo de la skill:
-
-Ejemplos:
-  • playwright-pom
-  • vercel-labs/skills/playwright-pom
-  • https://skills.sh/vercel-labs/skills/playwright-pom
+Introduce el nombre de la skill:
+Ejemplos: playwright-pom, typescript-utils, php-pro
 
 Skill: _
 ```
 
 ---
 
-### Paso 2: Verificar si Ya Existe
+## Paso 2 — Verificar duplicados
 
-**Usar módulo 09-module-list.md**:
-```python
-installed_skills = get_installed_skills()
+Comprobar si ya existe en las rutas oficiales:
 
-if skill_name in installed_skills:
-    location = installed_skills[skill_name].location  # "global" o "local"
-    show_already_installed_warning(skill_name, location)
+```bash
+# Nueva estructura
+ls ~/.claude/skills/<name>/SKILL.md 2>/dev/null
+ls ./.claude/skills/<name>/SKILL.md 2>/dev/null
+
+# Legacy
+ls ~/.claude/skills/<name>.md 2>/dev/null
+ls ./.claude/skills/<name>.md 2>/dev/null
 ```
 
-**Mostrar al usuario**:
+**Si ya existe:**
 ```
-⚠️ Skill Ya Instalada
-
-La skill "playwright-pom" ya está instalada en:
-  📍 Global: ~/.claude/skills/playwright-pom.md
+⚠️ "<name>" ya está instalada en: ~/.claude/skills/<name>/SKILL.md
 
 ¿Qué deseas hacer?
-
-1. Cancelar instalación
-2. Reinstalar (sobreescribir) en la misma ubicación
-3. Instalar en otra ubicación (global ↔ local)
-
-Elige [1-3]: _
+1. Cancelar
+2. Reinstalar (sobreescribir)
+3. Instalar también en local (además de global)
 ```
-
-**Si elige "1. Cancelar"**: Volver al menú
-
-**Si elige "2. Reinstalar"**: Continuar con misma ubicación
-
-**Si elige "3. Otra ubicación"**: Continuar y permitir elegir ubicación diferente
 
 ---
 
-### Paso 3: Elegir Ubicación
+## Paso 3 — Elegir scope
 
-**Preguntar al usuario**:
 ```
-📍 ¿Dónde instalar "playwright-pom"?
+📍 ¿Dónde instalar "<name>"?
 
-┌─────────────────────────────────────────────────────────────┐
-│ 1. 🌍 Global (~/.claude/skills/)                            │
-│    • Disponible en TODOS tus proyectos                     │
-│    • Recomendado para skills generales                     │
-│    • Ejemplo: llms, git-workflow, typescript               │
-└─────────────────────────────────────────────────────────────┘
+1. 🌍 Global (~/.claude/skills/<name>/SKILL.md)
+   • Disponible en TODOS tus proyectos
 
-┌─────────────────────────────────────────────────────────────┐
-│ 2. 📂 Local (./.claude/rules/)                              │
-│    • Solo para ESTE proyecto                               │
-│    • Recomendado para skills específicas del proyecto      │
-│    • Ejemplo: php-symfony, custom-validators               │
-└─────────────────────────────────────────────────────────────┘
-
-Elige [1-2]: _
+2. 📂 Local (./.claude/skills/<name>/SKILL.md)
+   • Solo para ESTE proyecto
 ```
-
-**Guardar elección**:
-```yaml
-install_config:
-  skill_name: "playwright-pom"
-  location: "global"  # o "local"
-  path: "~/.claude/skills/playwright-pom.md"  # o "./.claude/rules/playwright-pom.md"
-```
-
-**Nota sobre directorios**:
-- Global: Se usa `~/.claude/skills/` (convención moderna)
-- Local: Se usa `./.claude/rules/` (jerarquía oficial)
 
 ---
 
-### Paso 4: Ejecutar Instalación con Backend CLI
-
-**Comando npx skills**:
-```bash
-# Si el CLI de skills soporta flags de ubicación:
-npx skills add <skill-name> --location <global|local>
-
-# Si NO soporta (más probable):
-# Instalar manualmente copiando archivo
-```
-
-**Proceso de instalación manual** (más confiable):
-
-#### 4.1: Descargar Skill
+## Paso 4 — Ejecutar instalación
 
 ```bash
-# Opción 1: npx skills add descarga temporalmente
-npx skills add vercel-labs/skills/playwright-pom
-
-# Opción 2: Descargar directamente del repo
-curl -o /tmp/skill.md \
-  https://raw.githubusercontent.com/vercel-labs/skills/main/skills/playwright-pom/SKILL.md
+# Instalar con npx skills
+npx skills add <name> -a claude-code -y
 ```
 
-#### 4.2: Crear Directorio si No Existe
+Mostrar progreso:
+```
+📥 Instalando "<name>"...
+
+  ✓ Descargando desde skills.sh
+  ✓ Instalando con npx skills
+```
+
+### Adaptar a estructura oficial
+
+Tras la instalación, verificar la estructura creada por el CLI.
+Si el CLI crea un archivo plano (`<name>.md`), migrarlo a la estructura oficial:
 
 ```bash
-# Global
-mkdir -p ~/.claude/skills
-
-# Local
-mkdir -p ./.claude/rules
-```
-
-#### 4.3: Copiar Archivo
-
-```bash
-# Global
-cp /tmp/skill.md ~/.claude/skills/playwright-pom.md
-
-# Local
-cp /tmp/skill.md ./.claude/rules/playwright-pom.md
-```
-
-**Mostrar progreso**:
-```
-📥 Instalando "playwright-pom"...
-
-✓ Descargando skill desde skills.sh
-✓ Creando directorio ~/.claude/skills/
-✓ Copiando archivo
-✓ Verificando instalación
-
-✅ Instalación completada
-```
-
----
-
-### Paso 5: Configurar paths: (Si Necesario)
-
-**Detectar si la skill requiere paths:**
-
-**Leer archivo instalado**:
-```bash
-cat ~/.claude/skills/playwright-pom.md
-```
-
-**Buscar frontmatter con paths:**
-```yaml
----
-name: playwright-pom
-paths:
-  - "tests/**/*.spec.ts"
-  - "pages/**/*.ts"
----
-```
-
-**Si tiene paths: predefinidos**:
-```
-✅ Skill instalada con paths: configurados automáticamente
-
-Paths detectados:
-  • tests/**/*.spec.ts
-  • pages/**/*.ts
-
-Esta skill se activará en archivos que coincidan con estos patrones.
-```
-
-**Si NO tiene paths:**
-```
-⚙️ Configuración de paths:
-
-Esta skill NO tiene paths: configurados.
-
-Opciones:
-1. Usar sin paths: (se activará siempre)
-2. Configurar paths: manualmente (avanzado)
-3. Configurar más tarde
-
-Elige [1-3]: _
-```
-
-**Si elige "2. Configurar paths: manualmente"**:
-```
-📝 Configurar paths:
-
-Introduce patrones de archivos (uno por línea, vacío para terminar):
-
-Ejemplo:
-  tests/**/*.spec.ts
-  pages/**/*.ts
-
-Path 1: tests/**/*.spec.ts
-Path 2: pages/**/*.ts
-Path 3: [Enter para terminar]
-
-Guardando configuración...
-```
-
-**Actualizar archivo con paths:**
-```bash
-# Insertar frontmatter al inicio del archivo
-cat > ~/.claude/skills/playwright-pom.md << 'EOF'
----
-paths:
-  - "tests/**/*.spec.ts"
-  - "pages/**/*.ts"
----
-
-# [Contenido original de la skill...]
-EOF
-```
-
----
-
-### Paso 6: Verificar Instalación
-
-**Verificar que el archivo existe**:
-```bash
-if [ -f ~/.claude/skills/playwright-pom.md ]; then
-  echo "✅ Archivo creado correctamente"
-else
-  echo "❌ Error: Archivo no encontrado"
+# Si el CLI creó un archivo plano, migrar a directorio
+if [ -f ~/.claude/skills/<name>.md ] && [ ! -d ~/.claude/skills/<name> ]; then
+  mkdir -p ~/.claude/skills/<name>
+  mv ~/.claude/skills/<name>.md ~/.claude/skills/<name>/SKILL.md
 fi
 ```
 
-**Leer metadata**:
+Si el scope elegido es **local**:
 ```bash
-# Extraer nombre y descripción del frontmatter
-head -20 ~/.claude/skills/playwright-pom.md
-```
-
-**Confirmar al usuario**:
-```
-═══════════════════════════════════════════════════════════════
-✅ Skill Instalada Exitosamente
-═══════════════════════════════════════════════════════════════
-
-Skill: playwright-pom
-Descripción: Page Object Model patterns for Playwright
-Ubicación: Global (~/.claude/skills/)
-Archivo: ~/.claude/skills/playwright-pom.md
-Paths: tests/**/*.spec.ts, pages/**/*.ts
-
-La skill estará disponible en tu próxima sesión de Claude Code
-o cuando recargues la ventana.
-
-═══════════════════════════════════════════════════════════════
+mkdir -p ./.claude/skills/<name>
+# mover o copiar a ./.claude/skills/<name>/SKILL.md
 ```
 
 ---
 
-### Paso 6.5: Ofrecer Rule con Paths (Post-Instalación)
+## Paso 5 — Verificar instalación
 
-**Módulo**: `sections/15-module-post-install-rules.md`
+```bash
+# Verificar que el archivo existe en la ruta correcta
+ls ~/.claude/skills/<name>/SKILL.md   # global
+ls ./.claude/skills/<name>/SKILL.md   # local
+```
 
-Tras verificar la instalación, invocar el módulo 15 para ofrecer al usuario crear
-una **rule con frontmatter `paths:`** en `.claude/rules/`.
+Leer el frontmatter y mostrar:
+```
+══════════════════════════════════════════════════════════════
+✅ Skill instalada correctamente
+══════════════════════════════════════════════════════════════
 
-Esto permite que la skill se active **solo al tocar ficheros específicos**
-en vez de estar siempre activa (zero coste de contexto hasta activación).
+  Nombre:      <name>
+  Descripción: <description del frontmatter>
+  Ubicación:   ~/.claude/skills/<name>/SKILL.md
+  Estructura:  ✅ Formato oficial (<name>/SKILL.md)
 
-**Flujo resumido**:
-1. Preguntar si quiere crear rule con paths (recomendado)
-2. Si acepta: sugerir globs inteligentes según tipo de skill
-3. Detectar rules existentes (evitar duplicados, ofrecer agrupación)
-4. Crear fichero `.claude/rules/<nombre>.md` con frontmatter correcto
-5. Confirmar creación
-
-**Ver flujo completo**: `sections/15-module-post-install-rules.md`
+══════════════════════════════════════════════════════════════
+```
 
 ---
 
-### Paso 7: Acciones Posteriores
+## 🔥 Mensaje de lore épico al finalizar
 
-**Preguntar al usuario**:
+Tras confirmar la instalación exitosa, mostrar:
+
+```
+⚒️  Los Gwaith-i-Mírdain han sellado el trato.
+
+    "<name>" ha sido forjada en las fraguas de Eregion
+    y añadida a tu arsenal, viajero.
+
+    Que sirva bien en la Tierra Media.
+```
+
+---
+
+## Paso 6 — Acciones posteriores
+
 ```
 ¿Qué deseas hacer ahora?
 
-1. Instalar otra skill
-2. Ver skills instaladas (listar)
-3. Buscar más skills
-4. Volver al menú principal
-
-Elige [1-4]: _
+1. 📥 Instalar otra skill
+2. 🔍 Buscar más skills
+3. 🔙 Volver al menú principal
 ```
 
 ---
 
-## 🎨 Manejo de Errores
+## Manejo de errores
 
-### Error 1: Skill No Encontrada
+### Skill no encontrada en skills.sh
+```
+❌ "<name>" no existe en skills.sh
 
-**npx skills falla**:
-```bash
-npx skills add non-existent-skill
-# Error: Skill not found
+  • Verifica el nombre exacto
+  • Usa "Buscar" para encontrar skills disponibles
 ```
 
-**Mostrar**:
+### Error de permisos
 ```
-❌ Skill No Encontrada
+❌ Sin permisos para escribir en ~/.claude/skills/
 
-La skill "non-existent-skill" no existe en skills.sh
-
-Verificaciones:
-  • ✓ Nombre correcto
-  • ✓ Formato: nombre-skill (sin espacios)
-  • ✓ Busca primero con "1. Buscar Skills"
-
-¿Deseas buscar skills similares? [s/N]: _
+  Solución: chown -R $USER ~/.claude/
+  O bien: instala en local (./.claude/skills/)
 ```
 
-### Error 2: Sin Permisos
-
-**Falla al crear directorio**:
-```bash
-mkdir -p ~/.claude/skills
-# Error: Permission denied
+### Error de red
 ```
-
-**Mostrar**:
-```
-❌ Error de Permisos
-
-No se pudo crear el directorio ~/.claude/skills/
-
-Solución:
-  sudo chown -R $USER ~/.claude/
-
-O instalar en ubicación local (./.claude/rules/)
-
-¿Intentar instalación local? [s/N]: _
-```
-
-### Error 3: Network Error
-
-**No se puede descargar**:
-```
-❌ Error de Conexión
-
-No se pudo descargar la skill desde skills.sh
-
-Posibles causas:
-  • Sin conexión a internet
-  • skills.sh temporalmente no disponible
-  • Firewall bloqueando conexión
-
-Soluciones:
-  • Verifica tu conexión
-  • Reintenta en unos momentos
-  • Usa Backend Git en v2.2.0 (funciona offline)
-
-¿Reintentar? [s/N]: _
+⚠️ No se pudo descargar la skill.
+   Verifica tu conexión e inténtalo de nuevo.
 ```
 
 ---
 
-## 🔧 Características Avanzadas
-
-### Instalación en Batch (Futuro)
-
-**Instalar múltiples skills de una vez**:
-```
-📥 Instalación en Batch
-
-Skills a instalar:
-  1. playwright-pom
-  2. playwright-fixtures
-  3. typescript-utils
-
-Total: 3 skills
-Ubicación: Global
-
-¿Confirmar instalación? [s/N]: _
-
-Instalando...
-  ✓ playwright-pom
-  ✓ playwright-fixtures
-  ✓ typescript-utils
-
-✅ 3 skills instaladas exitosamente
-```
-
-### Plantillas de paths: por Tipo de Proyecto
-
-**Detectar tipo de proyecto** y sugerir paths:
-```
-📝 Paths: Sugeridos
-
-Proyecto detectado: Playwright E2E
-
-Paths recomendados:
-  • tests/**/*.spec.ts
-  • tests/**/*.test.ts
-  • pages/**/*.ts
-  • fixtures/**/*.ts
-
-¿Usar estos paths:? [S/n]: _
-```
-
----
-
-## 🔗 Integración con Otros Módulos
-
-### Con Módulo de Búsqueda (07)
-
-```python
-# Desde búsqueda
-search_results = search("playwright")
-user_selects = "2. Instalar una skill"
-
-# Llamar instalación con contexto
-install_module.run(
-    skill_name=search_results[selected_index].name,
-    from_search=True
-)
-```
-
-### Con Módulo de Listar (09)
-
-```python
-# Antes de instalar, verificar duplicados
-installed = list_module.get_installed_skills()
-
-if skill_name in installed:
-    handle_already_installed()
-```
-
-### Con Backend CLI (04)
-
-```python
-# Usar backend para instalación
-backend = selector.get_backend()
-result = backend.install(skill_name, location, config)
-```
-
----
-
-## 🎯 Reglas de Ejecución
-
-1. **SIEMPRE verificar duplicados** antes de instalar
-2. **Crear directorios** si no existen (mkdir -p)
-3. **Validar instalación** después de copiar archivo
-4. **Configurar paths:** si la skill lo requiere
-5. **Confirmar al usuario** instalación exitosa con detalles
-6. **Ofrecer acciones posteriores** (instalar otra, listar, etc.)
-7. **Manejo robusto de errores** (network, permisos, skill no encontrada)
-
----
-
-## 📊 Ejemplo Completo de Ejecución
-
-```
-Usuario: "2. Instalar Skill"
-
-═══════════════════════════════════════════════════════════════
-    📥 Instalar Skill
-═══════════════════════════════════════════════════════════════
-
-Skill: playwright-pom
-
-Verificando...
-⚠️ Skill ya instalada en Global
-
-¿Reinstalar? [s/N]: s
-
-───────────────────────────────────────────────────────────────
-
-📍 Ubicación:
-1. 🌍 Global (actual)
-2. 📂 Local
-
-Elige [1-2]: 1
-
-───────────────────────────────────────────────────────────────
-
-📥 Instalando "playwright-pom" en Global...
-
-✓ Descargando desde skills.sh
-✓ Creando directorio ~/.claude/skills/
-✓ Copiando archivo
-✓ Configurando paths: (automático)
-  • tests/**/*.spec.ts
-  • pages/**/*.ts
-✓ Verificando instalación
-
-═══════════════════════════════════════════════════════════════
-✅ Skill Instalada Exitosamente
-═══════════════════════════════════════════════════════════════
-
-Skill: playwright-pom
-Ubicación: ~/.claude/skills/playwright-pom.md
-Paths: tests/**/*.spec.ts, pages/**/*.ts
-
-═══════════════════════════════════════════════════════════════
-
-¿Qué deseas hacer?
-1. Instalar otra skill
-2. Ver skills instaladas
-3. Volver al menú
-
-Elige [1-3]: _
-```
-
----
-
-**Módulo anterior**: 07-module-search.md
-**Módulo siguiente**: 10-module-update.md
-**Integra con**: 07-module-search.md, 09-module-list.md, 04-backend-cli.md
-**Tarea**: #4 - Módulo Instalar (150 XP 💎)
+**Módulo**: `08-module-install.md`
+**Invocado desde**: `07-module-search.md` o `02-menu-principal.md`
+**Requiere**: Bash, Write


### PR DESCRIPTION
## Summary

- Reescribe `07-module-search.md`: rutas oficiales, sin referencias a módulos eliminados, flujo limpio
- Reescribe `08-module-install.md`: instala en estructura `<name>/SKILL.md`, migra automáticamente si el CLI crea archivo plano, sin `paths:` obsoleto, lore épico al finalizar
- Actualiza routing en `02-menu-principal.md` (opción 2)

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)