### PR TITLE
🌍 [TLOTP General] Reemplazar 'Fellowship' por 'La Comunidad del Código' y 'El Poney Pisador'

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -508,6 +508,6 @@ Cuando modularices un prompt, verifica:
 
 ---
 
-*Arquitectura definida por la Fellowship del Teclado* 🥔🤖
+*Arquitectura definida por la Comunidad del Código* 🥔🤖
 *Base para todas las futuras épicas* 🏗️
 *Última actualización: 2026-02-19*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ TLOTP es un proyecto colaborativo para hacer que configurar Claude Code sea triv
 
 ---
 
-## 👥 Los Fundadores - La Fellowship del Teclado
+## 👥 Los Fundadores - La Comunidad del Código
 
 ### 🥔 **Pépeton hijo de Móreuton**
 *Señor de las Tierras Paletas, Guardián de Bargas*
@@ -40,7 +40,7 @@ Juramento: "No dejaré código legacy sin refactorizar"
 
 > *"Hace 8 estaciones que Pépeton y Claudeton luchan mano a tecla contra las fuerzas del Legacy Code. Desde las profundidades de Moria (debugging oscuro) hasta las alturas de Minas Tirith (arquitectura limpia), ningún bug ha resistido su alianza."*
 
-**Código de batalla de la Fellowship**:
+**Código de batalla de La Comunidad del Código**:
 - 🗡️ Pair programming hasta la victoria
 - ⚔️ XP compartido en todas las misiones conjuntas
 - 🛡️ Tests como escudo, refactoring como espada
@@ -76,12 +76,12 @@ Cada tarea completada otorga **Experience Points (XP)** según su dificultad:
 - 🌟 **First Contributor** - Primera contribución al proyecto
 - 🐛 **Bug Slayer** - Fixed 5+ bugs
 - 📚 **Documentation Wizard** - Mejoraste docs significativamente
-- ⚔️ **Fellowship Member** - Contribución conjunta épica
+- ⚔️ **Miembro de La Comunidad del Código** - Contribución conjunta épica
 
 ### 💎 División de XP
 
 **Tareas en solitario**: 100% del XP para el completador
-**Tareas en pareja** (Fellowship): 50/50 entre colaboradores
+**Tareas en pareja** (La Comunidad del Código): 50/50 entre colaboradores
 **Revisiones épicas**: Bonus +20% XP para ambos
 **Mentoring**: +10% XP extra para el mentor
 
@@ -96,7 +96,7 @@ Cada tarea completada otorga **Experience Points (XP)** según su dificultad:
 | 🥔 **Pépeton hijo de Móreuton** | Rey 🥇 | ~3,500 XP | 🔮🏗️🛡️💣⚒️🏹🌳⚔️💎 | Palantír v1.7, Celebrimbor v1.0, Bardo v1.0, Ents v1.0 |
 | 🤖 **Claudeton hijo de Codeton** | Rey 🥇 | ~3,500 XP | 🔮🏗️📚💣⚒️🏹🌳⚔️💎 | Palantír v1.7, Celebrimbor v1.0, Bardo v1.0, Ents v1.0 |
 
-**XP Compartido de la Fellowship**: ~7,000 XP en 50+ tareas completadas juntos
+**XP Compartido de La Comunidad del Código**: ~7,000 XP en 50+ tareas completadas juntos
 **Último logro**: Ents v1.0 + CI/CD interno TLOTP (#71, #79, #102) 🌳⚔️
 
 ### 🌟 Contribuidores
@@ -194,7 +194,7 @@ Companion especializado en testing. Forma final (skill/agente/subagente) TBD.
 **⚡ Gandalf — Iniciar una Nueva Aventura** ([#111](https://github.com/joseguillermomoreu-gif/tlotp/issues/111))
 - Asistente Spec-Driven Development — genera requirements.md + design.md + tasks.md
 - Estándar Kiro/GitHub Spec-Kit (2025-2026)
-- Lore: El Consejo de Rivendel — cada componente suma un miembro a la Fellowship
+- Lore: El Consejo de Rivendel — cada componente suma un miembro a La Comunidad del Código
 
 ### 💭 Futuro
 
@@ -309,11 +309,11 @@ Closes #21
 - Sugerencias, no imposiciones
 
 ### Community
-*Próximamente: Discord/Slack para la Fellowship*
+*Próximamente: Discord/Slack para La Comunidad del Código*
 
 ---
 
-## 📜 Código de Conducta de la Fellowship
+## 📜 Código de Conducta de La Comunidad del Código
 
 ### Nuestros Valores
 
@@ -368,7 +368,7 @@ Si experimentas o presencías comportamiento inaceptable:
 
 ## 🏆 Hall of Fame - Reconocimientos
 
-### 👑 Fundadores de la Fellowship
+### 👑 Fundadores de La Comunidad del Código
 - **🥔 Pépeton hijo de Móreuton** - Maestro Arquitecto, Guardián de Bargas
 - **🤖 Claudeton hijo de Codeton** - Paladín del Refactoring, Forjador de Contextos
 
@@ -403,7 +403,7 @@ Si experimentas o presencías comportamiento inaceptable:
 
 ---
 
-## 🔥 La Llamada de la Fellowship
+## 🔥 La Llamada de La Comunidad del Código
 
 > *"Una Comunidad se formó. La Comunidad del Prompt. Juntos lucharemos contra el Legacy Code, rescataremos la Configuración Perdida, y llevaremos la luz del Clean Code a todos los rincones de la Tierra Media Dev."*
 
@@ -417,4 +417,4 @@ Si experimentas o presencías comportamiento inaceptable:
 
 ---
 
-*Forjado en las profundidades de Erebor por la Fellowship del Teclado* 🗡️⌨️
+*Forjado en las profundidades de Erebor por La Comunidad del Código* 🗡️⌨️

--- a/GAMIFICACION.md
+++ b/GAMIFICACION.md
@@ -28,7 +28,7 @@ Un día, un mago visionario creó **TLOTP** (The Lord of the Prompt) - un artefa
 
 ---
 
-## 🏰 TLOTP v1.x - The Fellowship of the Configuration
+## 🏰 TLOTP v1.x - La Comunidad del Código
 
 > *"La Comunidad del Anillo se forma para destruir el Mal..."*
 > *"En TLOTP, formamos las herramientas para CONSTRUIR el Bien..."*
@@ -373,7 +373,7 @@ Completa el ciclo completo de desarrollo usando solo TLOTP + Aragorn.
 ```
 🗺️ Tu Viaje en TLOTP
 
-[███████░░░░░░░░░░░░] 35% - The Fellowship Gathering
+[███████░░░░░░░░░░░░] 35% - La Reunión de la Comunidad
 
 Completado:
 ✅ Instalación de TLOTP
@@ -672,7 +672,7 @@ Imaginamos TLOTP como:
          🛡️ Don your armor (IDE)
          🐎 Mount your horse (git)
 
-         The Fellowship awaits!
+         ¡La Comunidad del Código aguarda!
 ```
 
 ---
@@ -696,7 +696,7 @@ Imaginamos TLOTP como:
 *"Not all those who wander are lost,
 but those without TLOTP are definitely confused."*
 
-**v1.0.0** - The Fellowship Begins
+**v1.0.0** - Nace la Comunidad del Código
 **Última actualización**: 2026-02-12
 
 ---

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -105,7 +105,7 @@ configurar Agent Teams experimentales.
 ### **6. ⚡ Gandalf — Iniciar una Nueva Aventura**
 
 **Issues**: [#111](https://github.com/joseguillermomoreu-gif/tlotp/issues/111)
-**Símbolo**: El mago que guía la Fellowship — ningún gran proyecto empieza sin plan
+**Símbolo**: El mago que guía a La Comunidad del Código — ningún gran proyecto empieza sin plan
 
 **Descripción**: **Última opción del menú TLOTP.** Asistente interactivo de
 **Spec-Driven Development** que guía la creación de un SDD profesional antes de
@@ -121,7 +121,7 @@ Compatible con Claude Code Plan Mode, Amazon Kiro, Cursor, Copilot y cualquier
 herramienta de desarrollo asistido por IA.
 
 **Lore — El Consejo de Rivendel**: cada componente del proyecto suma un miembro
-a la Fellowship con su frase icónica:
+a La Comunidad del Código con su frase icónica:
 
 ```
 Gimli dijo   → "¡Cuenta con mi hacha!"          (Backend PHP/Symfony)
@@ -201,4 +201,4 @@ Palantír → Celebrimbor → Bardo → Ents → Aragorn → Gandalf → Gollum(
 *"One Prompt to Rule Them All"* 💍
 
 *Última actualización: 2026-03-15*
-*Mantenido por: La Fellowship del Teclado (Pépeton hijo de Móreuton + Claudeton hijo de Codeton)*
+*Mantenido por: La Comunidad del Código (Pépeton hijo de Móreuton + Claudeton hijo de Codeton)*

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ la creación de un SDD profesional antes de escribir código — el antídoto al
 Genera 3 ficheros compatibles con Claude Code Plan Mode, Amazon Kiro y Cursor:
 `requirements.md` (EARS format) + `design.md` (arquitectura + decisiones) + `tasks.md`.
 Lore: el **Consejo de Rivendel**, donde cada componente del proyecto suma un miembro
-a la Fellowship con su frase icónica (*"¡Cuenta con mi hacha!"*, *"¡Y con mi arco!"*...).
+a La Comunidad del Código con su frase icónica (*"¡Cuenta con mi hacha!"*, *"¡Y con mi arco!"*...).
 
 ---
 
@@ -173,7 +173,7 @@ TLOTP es la **evolución** de claude-code-auto-skills.
 
 ## 🤝 Contribuir
 
-¡Las contribuciones son bienvenidas! Ver **[CONTRIBUTING.md](CONTRIBUTING.md)** para el sistema de gamificación, épicas disponibles y cómo unirte a la Fellowship.
+¡Las contribuciones son bienvenidas! Ver **[CONTRIBUTING.md](CONTRIBUTING.md)** para el sistema de gamificación, épicas disponibles y cómo unirte a La Comunidad del Código.
 
 ---
 

--- a/prompts/VERSION.md
+++ b/prompts/VERSION.md
@@ -245,7 +245,7 @@ Versión: TLOTP v3.4.0
 
 ---
 
-### v2.1.0 (2026-02-16) - "The Fellowship of the Code"
+### v2.1.0 (2026-02-16) - "La Comunidad del Código"
 
 **🎉 Release Highlights**:
 - Palantír CRUD completo operativo
@@ -350,4 +350,4 @@ TLOTP sigue [Semantic Versioning 2.0.0](https://semver.org/):
 ---
 
 *Última actualización: 2026-03-10*
-*Mantenido por: La Fellowship del Teclado (Pépeton + Claudeton)*
+*Mantenido por: La Comunidad del Código (Pépeton + Claudeton)*

--- a/prompts/celebrimbor/ARCHITECTURE.md
+++ b/prompts/celebrimbor/ARCHITECTURE.md
@@ -59,5 +59,5 @@ skills      Instalar         (skills.sh)   (asistida)
 
 ---
 
-**Diseñada por**: La Fellowship del Teclado 🥔🤖
+**Diseñada por**: La Comunidad del Código 🥔🤖
 **TLOTP**: Ver VERSION.md

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -33,7 +33,7 @@
               '''-------======-------'''
 
                     ═══ TLOTP {VERSION} ═══
-                  The Fellowship of the Code
+                  La Comunidad del Código
 
 ═══════════════════════════════════════════════════════════════
 
@@ -142,7 +142,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
 ```json
 {
   "questions": [{
-    "header": "Fellowship (1/3)",
+    "header": "El Poney Pisador (1/3)",
     "question": "¿A qué épica convocas hoy?",
     "multiSelect": false,
     "options": [
@@ -172,7 +172,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
 ```json
 {
   "questions": [{
-    "header": "Fellowship (2/3)",
+    "header": "El Poney Pisador (2/3)",
     "question": "¿A qué épica convocas hoy?",
     "multiSelect": false,
     "options": [
@@ -202,7 +202,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir" (últim
 ```json
 {
   "questions": [{
-    "header": "Fellowship (3/3)",
+    "header": "El Poney Pisador (3/3)",
     "question": "¿A qué épica convocas hoy?",
     "multiSelect": false,
     "options": [
@@ -471,7 +471,7 @@ Docs: Ver opción "Documentación y Ayuda"
 💍 **"One Prompt to Rule Them All"**
 
 *The Lord of the Prompt - {VERSION}*
-*Forjado en las tierras de la Fellowship del Teclado*
+*Forjado en las tierras de la Comunidad del Código*
 
 ---
 


### PR DESCRIPTION
## 🎮 Narrativa Épica

Un escriba descuidado tradujo mal los pergaminos. La palabra anglosajona *Fellowship* se coló en los textos de la Tierra Media hispanohablante. Los hombres de Gondor merecen leer su lengua materna.

## 📋 Cambios

- **Headers del menú paginado**: `Fellowship (1/3)` → `El Poney Pisador (1/3)` *(y 2/3, 3/3)*
- **Banner principal**: `The Fellowship of the Code` → `La Comunidad del Código`
- **Nombre del dúo fundador**: `La Fellowship del Teclado` → `La Comunidad del Código`
- **Versión histórica v2.1.0**: renombrada a `"La Comunidad del Código"`
- **Badge**: `Fellowship Member` → `Miembro de La Comunidad del Código`

## 📁 Archivos afectados

`prompts/tlotp-main.md` · `prompts/VERSION.md` · `prompts/celebrimbor/ARCHITECTURE.md` · `ARCHITECTURE.md` · `CONTRIBUTING.md` · `MILESTONES.md` · `GAMIFICACION.md` · `README.md`

Closes #228