### PR TITLE
⚒️ [Celebrimbor] Refactor menú principal: paginación, lore, navegación y módulos huérfanos

### DIFF
--- a/prompts/celebrimbor/celebrimbor-main.md
+++ b/prompts/celebrimbor/celebrimbor-main.md
@@ -50,8 +50,8 @@ Celebrimbor gestiona skills de Claude Code: busca e instala desde skills.sh, ana
 - **08-module-install.md** — Instalar skills
 - **11-module-update.md** — Actualizar skills
 - **12-module-create-skill.md** — Crear skill asistida (nueva)
-- **09-module-list.md** — Listar skills instaladas
-- **10-module-remove.md** — Eliminar skills
+- **09-module-list.md** — Listar skills instaladas *(accesible desde opción Inventario)*
+- **10-module-remove.md** — Eliminar skills *(accesible desde opción Inventario)*
 - **11-module-update.md** — Actualizar skills
 
 ### Referencia Técnica
@@ -82,16 +82,24 @@ npx skills check
 ```
 Si hay updates, avisarlo en el menú.
 
-### Paso 4: Menú Principal (loop)
+### Paso 4: Menú Principal (loop paginado)
 
 **Módulo**: `sections/02-menu-principal.md`
 
+Menú paginado (3 pantallas, 2 opciones de contenido por pantalla):
+
 ```
-1. 🔍 Analizar skills instaladas y sugerir mejoras
-2. 📦 Buscar e instalar skills (skills.sh)
-3. 🔄 Actualizar skills (skills.sh)
-4. ✨ Crear una skill (asistido)
-5. 🚪 Salir de Eregion
+Pantalla 1/3:
+  🔍 Examinar las forjas de Eregion — Analizar y mejorar
+  📦 Explorar el mercado de Ost-in-Edhil — Buscar e instalar
+
+Pantalla 2/3:
+  🔄 Reafilar las hojas en la fragua — Actualizar skills
+  ✨ Forjar desde cero — Crear nueva skill asistida
+
+Pantalla 3/3:
+  ⚔️ Revisar el inventario de la Forja — Listar y eliminar
+  🔙 Abandonar Eregion — Volver a La Comunidad del Código
 ```
 
 ---
@@ -116,6 +124,13 @@ prompts/celebrimbor/
     ├── 12-module-create-skill.md # Crear skill asistida ✨
     └── 14-skills-cli-reference.md # Referencia técnica CLI
 ```
+
+---
+
+## 🗺️ Navegación entre épicas
+
+- **Volver a La Comunidad del Código**: Cargar `@prompts/tlotp-main.md` para retomar el menú principal de TLOTP
+- **Salir de Eregion**: Finalizar la sesión completamente con despedida épica
 
 ---
 

--- a/prompts/celebrimbor/sections/02-menu-principal.md
+++ b/prompts/celebrimbor/sections/02-menu-principal.md
@@ -77,20 +77,104 @@ Guardar resultado. Si hay updates disponibles, mostrarlo en el menú como aviso:
 
 ---
 
-## 🗡️ Menú Principal
+## 🗡️ Menú Principal (PAGINADO)
 
-Mostrar con `AskUserQuestion`:
+**CRÍTICO**: Usar **AskUserQuestion** (límite 4 opciones). El menú se divide en 3 pantallas.
+Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir de Eregion" (última página: "🔙 Volver al inicio" en lugar de "➕ Ver más...").
 
+Mostrar aviso de updates si procede:
 ```
-⚒️ La Forja de Eregion — ¿Cuál es tu trato, viajero?
+⚠️  Hay skills con actualizaciones disponibles → Opción de actualizar
+```
 
-  {AVISO_UPDATES_SI_PROCEDE}
+**Pantalla 1** (mostrar primero):
 
-  1. 🔍  Analizar skills instaladas y sugerir mejoras
-  2. 📦  Buscar e instalar skills (skills.sh)
-  3. 🔄  Actualizar skills (skills.sh)
-  4. ✨  Crear una skill (asistido)
-  5. 🚪  Salir de Eregion
+```json
+{
+  "questions": [{
+    "header": "La Forja de Eregion (1/3)",
+    "question": "¿Cuál es tu trato, viajero?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🔍 Examinar las forjas de Eregion — Analizar y mejorar",
+        "description": ""
+      },
+      {
+        "label": "📦 Explorar el mercado de Ost-in-Edhil — Buscar e instalar",
+        "description": ""
+      },
+      {
+        "label": "➕ Ver más...",
+        "description": ""
+      },
+      {
+        "label": "🚪 Salir de Eregion",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+**Si elige "➕ Ver más..."**, mostrar **Pantalla 2**:
+
+```json
+{
+  "questions": [{
+    "header": "La Forja de Eregion (2/3)",
+    "question": "¿Cuál es tu trato, viajero?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🔄 Reafilar las hojas en la fragua — Actualizar skills",
+        "description": ""
+      },
+      {
+        "label": "✨ Forjar desde cero — Crear nueva skill asistida",
+        "description": ""
+      },
+      {
+        "label": "➕ Ver más...",
+        "description": ""
+      },
+      {
+        "label": "🚪 Salir de Eregion",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+**Si elige "➕ Ver más..."**, mostrar **Pantalla 3**:
+
+```json
+{
+  "questions": [{
+    "header": "La Forja de Eregion (3/3)",
+    "question": "¿Cuál es tu trato, viajero?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "⚔️ Revisar el inventario de la Forja — Listar y eliminar",
+        "description": ""
+      },
+      {
+        "label": "🔙 Abandonar Eregion — Volver a La Comunidad del Código",
+        "description": ""
+      },
+      {
+        "label": "🔙 Volver al inicio",
+        "description": ""
+      },
+      {
+        "label": "🚪 Salir de Eregion",
+        "description": ""
+      }
+    ]
+  }]
+}
 ```
 
 **Loop continuo**: al terminar cada módulo, volver a este menú (sin repetir banner ni permisos).
@@ -99,30 +183,44 @@ Mostrar con `AskUserQuestion`:
 
 ## Flujo de Navegación
 
-### Opción 1: Analizar skills y sugerir mejoras
+### "🔍 Examinar las forjas de Eregion — Analizar y mejorar"
 - Cargar módulo: `sections/07-module-analyze.md`
 - Inspeccionar skills instaladas en rutas oficiales
 - Comparar con doc oficial (WebFetch on-demand si no está en contexto)
 - Mostrar resumen con sugerencias
 
-### Opción 2: Buscar e instalar skills (skills.sh)
+### "📦 Explorar el mercado de Ost-in-Edhil — Buscar e instalar"
 - Cargar módulo: `sections/07-module-search.md` → continúa en `sections/08-module-install.md`
 - Buscar en skills.sh con `npx skills find <query>`
 - Instalar en estructura `<name>/SKILL.md`
 - Mostrar mensaje de lore épico al finalizar
 
-### Opción 3: Actualizar skills (skills.sh)
+### "🔄 Reafilar las hojas en la fragua — Actualizar skills"
 - Cargar módulo: `sections/11-module-update.md`
 - Mostrar skills con updates disponibles
 - Confirmar y ejecutar `npx skills update`
 
-### Opción 4: Crear una skill (asistido)
+### "✨ Forjar desde cero — Crear nueva skill asistida"
 - Cargar módulo: `sections/12-module-create-skill.md`
-- WebFetch on-demand a `https://code.claude.com/docs/en/skills`
+- WebFetch on-demand a la documentación oficial de skills
 - Guiar al usuario paso a paso (nombre, tipo, description, invocación, contenido)
 - Mostrar lore épico al finalizar
 
-### Opción 5: Salir de Eregion
+### "⚔️ Revisar el inventario de la Forja — Listar y eliminar"
+- Mostrar sub-menú (AskUserQuestion):
+  - `📋 Ver el inventario completo — Listar skills instaladas` → `sections/09-module-list.md`
+  - `🗑️ Retirar una pieza de la Forja — Eliminar skill` → `sections/10-module-remove.md`
+  - `🔙 Volver al menú principal`
+
+### "🔙 Abandonar Eregion — Volver a La Comunidad del Código"
+- Finalizar el loop de Celebrimbor
+- Mostrar despedida breve:
+```
+Los Gwaith-i-Mírdain guardan el fuego hasta tu regreso, viajero.
+```
+- Cargar `@prompts/tlotp-main.md` para retomar el menú principal de TLOTP
+
+### "🚪 Salir de Eregion"
 ```
 Los Gwaith-i-Mírdain guardan el fuego hasta tu regreso.
 Que tus skills sirvan bien en la Tierra Media, viajero.


### PR DESCRIPTION
## 🎮 Narrativa Épica

Los herreros de Ost-in-Edhil han reorganizado el portal de entrada. Ya no hay muros de texto sin alma — ahora la Forja recibe a los viajeros con lore, con orden y con la opción de volver a La Comunidad del Código cuando su misión en Eregion haya concluido.

## 📋 Cambios

- **Menú paginado**: 3 pantallas con patrón idéntico al menú principal de TLOTP (`La Forja de Eregion (1/3)`, `(2/3)`, `(3/3)`)
- **Lore épico** en todos los labels de opciones
- **Nueva opción**: `🔙 Abandonar Eregion — Volver a La Comunidad del Código`
- **Módulos huérfanos integrados**: 09 (listar) y 10 (eliminar) ahora accesibles bajo `⚔️ Revisar el inventario de la Forja`
- **Sub-menú de inventario** con navegación propia
- **`celebrimbor-main.md`** actualizado con nuevo flujo y sección de navegación entre épicas

## 📁 Archivos afectados

`prompts/celebrimbor/sections/02-menu-principal.md` · `prompts/celebrimbor/celebrimbor-main.md`

Closes #225