### PR TITLE
⚒️ [Celebrimbor] Potenciar módulo Analizar: scoring, doc oficial e integración Palantír

### DIFF
--- a/prompts/celebrimbor/sections/07-module-analyze.md
+++ b/prompts/celebrimbor/sections/07-module-analyze.md
@@ -2,26 +2,59 @@
 
 ## Misión
 
-Inspeccionar las skills instaladas del usuario, comparar con la documentación oficial de Claude Code y mostrar un informe con sugerencias de mejora.
-
-**Documentación oficial** (WebFetch on-demand si no está en contexto):
-```
-https://code.claude.com/docs/en/skills
-```
+Inspeccionar las skills instaladas del usuario, puntuar su estado actual, comparar con
+la documentación oficial y proponer mejoras concretas. Con el Palantír activo, el análisis
+se extiende a detectar colisiones y redundancias entre configuraciones y skills.
 
 ---
 
-## Paso 0 — Fetch on-demand de doc oficial
+## Paso 0 — Documentación oficial (on-the-fly)
 
-Antes de analizar, verificar si la documentación oficial de skills ya está cargada en el contexto de la conversación.
+**IMPORTANTE**: Comprobar primero si la documentación ya está cargada en el
+contexto de esta sesión (por haber ejecutado previamente otro módulo que haya hecho WebFetch).
 
-- **Si está disponible**: usar directamente
-- **Si no está disponible**: hacer WebFetch a `https://code.claude.com/docs/en/skills`
+**Si ya está en contexto**: usar directamente esa información sin re-fetchear.
 
-Extraer y retener:
-- Estructura oficial de skills (`<name>/SKILL.md`)
-- Campos válidos de frontmatter: `name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks`
-- Rutas oficiales de instalación
+**Si no está en contexto**, hacer WebFetch:
+
+> **WebFetch 1**: `https://code.claude.com/docs/en/skills`
+> **Extraer**: Estructura oficial de SKILL.md, campos válidos de frontmatter, rutas de instalación,
+> control de invocación, patrones recomendados, campos obsoletos.
+
+> **WebFetch 2**: `https://github.com/vercel-labs/skills`
+> **Extraer**: Versiones disponibles de skills en el catálogo, comandos de actualización,
+> estructura esperada, campos que el CLI gestiona.
+
+**Fallback si WebFetch falla**: Continuar con conocimiento interno marcando sugerencias con ⚠️ sin doc oficial.
+
+---
+
+## Paso 0.5 — ¿Traes tu Palantír?
+
+Preguntar con `AskUserQuestion` antes de iniciar el análisis:
+
+```json
+{
+  "questions": [{
+    "header": "La Piedra Vidente",
+    "question": "¿Traes tu Palantír contigo, viajero? Con él, la Forja puede ver mucho más lejos y detectar conflictos entre tus configuraciones y tus skills.",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🔮 Sí — análisis completo con Palantír",
+        "description": ""
+      },
+      {
+        "label": "⚒️ No — análisis estándar de skills",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+- **Con Palantír**: ejecutar Pasos 1–5 + Paso 6 (análisis cruzado)
+- **Sin Palantír**: ejecutar solo Pasos 1–5
 
 ---
 
@@ -51,29 +84,38 @@ Para cada skill encontrada, leer su contenido para extraer el frontmatter.
 
 ---
 
-## Paso 2 — Analizar cada skill
+## Paso 2 — Analizar y puntuar cada skill
 
-Para cada skill, verificar:
+Para cada skill, evaluar según los siguientes criterios. Cada skill parte de **10 puntos** y se penaliza:
 
-### ✅ Estructura
-- **Nueva** (`<name>/SKILL.md` en directorio) → ✅ Correcto
-- **Legacy** (`<name>.md` archivo plano) → ⚠️ Funciona, pero considera migrar al formato de directorio
+### Criterios de scoring por skill
 
-### ✅ Frontmatter
-- ¿Tiene `description`? → Sin description, Claude no sabe cuándo usarla automáticamente → ❌ Crítico
-- ¿El `description` es descriptivo (>15 caracteres)? → ⚠️ Mejorable si es muy corto
-- ¿Tiene `name`? → Opcional, pero recomendable para claridad
-- ¿Tiene campos obsoletos? (`paths:` ya no existe en la doc oficial) → ❌ Obsoleto
+| Criterio | Penalización | Severidad |
+|----------|-------------|-----------|
+| Sin `description` en frontmatter | -4 pts | ❌ Crítico |
+| `description` demasiado corta (<15 chars) | -2 pts | ⚠️ Mejorable |
+| Formato legacy (archivo plano, no directorio) | -2 pts | ⚠️ Mejorable |
+| Campo obsoleto en frontmatter (`paths:` u otros no oficiales) | -3 pts | ❌ Crítico |
+| Configuración de invocación inconsistente con el tipo de skill | -1 pt | ℹ️ Revisable |
 
-### ✅ Configuración de invocación
-- ¿Tiene `disable-model-invocation: true`? → Solo puede invocarla el usuario
-- ¿Tiene `user-invocable: false`? → Solo puede invocarla Claude
-- Sin ambos → Claude y usuario pueden invocarla (comportamiento por defecto)
-- Verificar que la configuración tiene sentido según el tipo de skill
+### Niveles de calidad por skill
+
+| Puntos | Nivel | Descripción |
+|--------|-------|-------------|
+| 9–10 | ⚒️ Obra maestra | Skill perfectamente forjada |
+| 7–8 | ⚔️ Bien forjada | Solo mejoras menores |
+| 5–6 | 🧙 En proceso | Necesita trabajo |
+| < 5 | 🐛 En el horno | Requiere refuerzo urgente |
+
+### Score global
+
+```
+Score global = media de puntuaciones individuales (redondeado a 1 decimal)
+```
 
 ---
 
-## Paso 3 — Generar informe
+## Paso 3 — Generar informe con scoring
 
 ```
 ══════════════════════════════════════════════════════════════
@@ -82,34 +124,37 @@ Para cada skill, verificar:
 
 🌍 PERSONAL (~/.claude/skills/)
 ──────────────────────────────────────────────────────────────
-  ✅ playwright-pom/SKILL.md    — estructura correcta, description OK
-  ⚠️  git-workflow.md           — archivo plano (legacy), considera migrar
-  ❌  php-pro/SKILL.md          — sin description en frontmatter
+  ⚒️ 10/10  playwright-pom/SKILL.md    — estructura correcta, description OK
+  ⚔️  8/10  git-workflow.md            — archivo plano (legacy), migrar a directorio
+  ❌  6/10  php-pro/SKILL.md           — sin description en frontmatter
 
 📂 PROYECTO (./.claude/skills/)
 ──────────────────────────────────────────────────────────────
-  ⚠️  typescript-utils.md       — tiene paths: obsoleto, archivo plano
+  🧙  4/10  typescript-utils.md        — paths: obsoleto + archivo plano
 
 📁 LEGACY COMMANDS
 ──────────────────────────────────────────────────────────────
-  ℹ️  deploy.md                 — legacy command, funciona igual que skill
+  ℹ️  —     deploy.md                  — legacy command, funciona igual que skill
 
 ══════════════════════════════════════════════════════════════
-📊 Resumen: 5 skills · 1 ✅ correcta · 2 ⚠️ mejorables · 1 ❌ crítica
+📊 Score global: 7.0/10 ⚔️ — 5 skills · 1 ⚒️ · 1 ⚔️ · 1 🧙 · 1 ❌ crítica
 ══════════════════════════════════════════════════════════════
 ```
 
 ---
 
-## Paso 4 — Sugerencias accionables
+## Paso 4 — Sugerencias accionables (basadas en doc oficial)
 
-Para cada issue encontrado, mostrar la sugerencia específica:
+Para cada issue encontrado, mostrar la sugerencia específica derivada de la documentación oficial cargada en el Paso 0.
+
+Ordenar: ❌ Críticos primero, ⚠️ Mejorables después, ℹ️ Informativos al final.
 
 ### ❌ Sin description
 ```
 skill: php-pro/SKILL.md
 Problema: Sin campo description en el frontmatter
 Impacto: Claude no sabe cuándo activar esta skill automáticamente
+Fuente: documentación oficial skills (Paso 0)
 
 Sugerencia: Añadir al frontmatter:
   description: "Aplica cuando trabajas con PHP 8.3+, Laravel o Symfony.
@@ -127,10 +172,10 @@ Sugerencia: Migrar a directorio:
   mv ~/.claude/skills/git-workflow.md ~/.claude/skills/git-workflow/SKILL.md
 ```
 
-### ⚠️ Campo paths: obsoleto
+### ❌ Campo obsoleto
 ```
 skill: typescript-utils.md
-Problema: Tiene paths: en el frontmatter — campo obsoleto
+Problema: Tiene paths: en el frontmatter — campo obsoleto según doc oficial
 Impacto: El campo es ignorado por Claude Code
 
 Sugerencia: Eliminar el bloque paths: del frontmatter
@@ -142,12 +187,28 @@ Sugerencia: Eliminar el bloque paths: del frontmatter
 
 Mostrar con `AskUserQuestion`:
 
-```
-¿Qué deseas hacer?
-
-1. 🔧 Aplicar sugerencias una a una
-2. 📋 Ver detalles completos de una skill
-3. 🔙 Volver al menú principal
+```json
+{
+  "questions": [{
+    "header": "Tras el análisis",
+    "question": "¿Qué deseas hacer con los resultados?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🔧 Aplicar sugerencias una a una",
+        "description": ""
+      },
+      {
+        "label": "📋 Ver detalles completos de una skill",
+        "description": ""
+      },
+      {
+        "label": "🔙 Volver al menú principal",
+        "description": ""
+      }
+    ]
+  }]
+}
 ```
 
 ### Si elige "Aplicar sugerencias una a una"
@@ -177,6 +238,103 @@ Análisis completado:
 
 ---
 
+## Paso 6 — Análisis cruzado con Palantír (solo si usuario aceptó en Paso 0.5)
+
+### Paso 6.1 — Documentación de Palantír (on-the-fly)
+
+**IMPORTANTE**: Comprobar si la documentación de memoria/configuración ya está en contexto.
+
+**Si ya está en contexto**: usar directamente sin re-fetchear.
+
+**Si no está en contexto**, hacer WebFetch:
+
+> **WebFetch**: `https://code.claude.com/docs/en/memory`
+> **Extraer**: Jerarquía de memoria (7 niveles), tipos de archivos de configuración,
+> precedencia, cómo interactúan las rules y las skills.
+
+### Paso 6.2 — Leer configuraciones del usuario
+
+```bash
+# Configuración global
+cat ~/.claude/CLAUDE.md 2>/dev/null
+ls ~/.claude/rules/*.md 2>/dev/null
+ls ~/.claude/memory/*.md 2>/dev/null
+
+# Configuración del proyecto actual
+cat ./.claude/CLAUDE.md 2>/dev/null || cat ./CLAUDE.md 2>/dev/null
+ls ./.claude/rules/*.md 2>/dev/null
+```
+
+### Paso 6.3 — Análisis cruzado
+
+Con las configuraciones y skills cargadas, detectar:
+
+#### 🔴 Colisiones — instrucciones que se contradicen
+Instrucciones en CLAUDE.md o rules que contradicen o solapan instrucciones de una skill activa.
+
+```
+🔴 COLISIÓN detectada:
+  Config:  CLAUDE.md línea 12 → "Usa siempre TypeScript strict"
+  Skill:   typescript-utils/SKILL.md → "Permite JS cuando el proyecto no tiene tsconfig"
+  Impacto: Comportamiento inconsistente según qué instrucción prevalezca
+  Jerarquía: La skill tiene precedencia sobre CLAUDE.md global (doc oficial)
+```
+
+#### 🟡 Redundancias — instrucciones duplicadas
+Instrucciones en las configs que ya están cubiertas completamente por una skill activa.
+
+```
+🟡 REDUNDANCIA detectada:
+  Config:  ~/.claude/CLAUDE.md → bloque de convenciones de commits
+  Skill:   git-workflow/SKILL.md → cubre exactamente las mismas convenciones
+  Acción:  Puedes eliminar el bloque de CLAUDE.md y dejar que la skill lo gestione
+```
+
+#### 🔵 Pertinencia — skills vs scope del proyecto
+Comparar las skills instaladas contra el stack y propósito del proyecto actual.
+
+```
+🔵 ANÁLISIS DE PERTINENCIA:
+  Proyecto detectado: PHP/Symfony (por CLAUDE.md y estructura de archivos)
+
+  ✅ Skills relevantes para este proyecto:
+     • php-pro — directamente aplicable
+     • git-workflow — universal, siempre útil
+
+  ⚠️ Skills sin uso aparente en este proyecto:
+     • react-patterns — no hay archivos .tsx ni .jsx detectados
+
+  💡 Skills recomendadas para este stack (no instaladas):
+     • php-pro (si no está) — mejores prácticas PHP 8.3+/Symfony
+     • (basado en catálogo oficial, WebFetch ya cargado)
+```
+
+#### 🟢 Calidad de instalación
+```
+🟢 CALIDAD DE INSTALACIÓN:
+  ✅ playwright-pom — estructura correcta, path correcto
+  ⚠️ git-workflow — archivo plano, considera migrar (ya señalado en análisis base)
+```
+
+### Paso 6.4 — Informe cruzado
+
+```
+══════════════════════════════════════════════════════════════
+🔮 ANÁLISIS CRUZADO — Forja + Palantír
+══════════════════════════════════════════════════════════════
+
+🔴 Colisiones:    X encontradas
+🟡 Redundancias:  X encontradas
+🔵 Pertinencia:   X skills sin uso aparente · X recomendadas
+🟢 Instalación:   X correctas · X mejorables
+
+══════════════════════════════════════════════════════════════
+```
+
+Ofrecer las mismas opciones del Paso 5 para aplicar correcciones.
+
+---
+
 ## Casos especiales
 
 ### Sin skills instaladas
@@ -200,11 +358,21 @@ Rutas verificadas:
 ✅ Todas las skills están correctas y bien configuradas.
    Eregion aprueba tu colección, viajero.
 
-Total: X skills · 0 issues encontrados
+Score global: 10/10 ⚒️ — X skills · todas obras maestras
 ```
 
 ---
 
+## 🔗 Fuentes
+
+Ver índice completo en `@prompts/docs-sources.md`:
+- Skills nativas: `https://code.claude.com/docs/en/skills`
+- CLI skills.sh: `https://github.com/vercel-labs/skills`
+- Memoria/configuración (Palantír): `https://code.claude.com/docs/en/memory`
+
+---
+
 **Módulo**: `07-module-analyze.md`
-**Invocado desde**: `02-menu-principal.md` (Opción 1)
+**Invocado desde**: `02-menu-principal.md` (opción "Examinar las forjas de Eregion")
 **Requiere**: WebFetch on-demand, Read, Edit (para aplicar sugerencias)
+**Opcional**: Bash (para listar archivos), Read (configs de Palantír)


### PR DESCRIPTION
## 🎮 Narrativa Épica

> *"Ver no es suficiente. Un Palantír sin interpretación es solo un espejo oscuro."*

Celebrimbor ya no se limita a describir lo que ve. Ahora puntúa, juzga, y cuando el viajero porta una Piedra Vidente, detecta conflictos y redundancias que ningún ojo ordinario podría ver.

## 📋 Cambios en `07-module-analyze.md`

### Scoring por skill (0-10)
- Criterios con penalización documentada: sin `description` (-4), legacy format (-2), campos obsoletos (-3), description corta (-2), invocación inconsistente (-1)
- 4 niveles: ⚒️ Obra maestra · ⚔️ Bien forjada · 🧙 En proceso · 🐛 En el horno
- Score global = media de puntuaciones individuales

### WebFetch condicional mejorado
- Comprueba contexto antes de re-fetchear (patrón Ents)
- Añade WebFetch 2: `https://github.com/vercel-labs/skills` para comparar con catálogo
- Fallback con ⚠️ si WebFetch falla

### Paso 0.5 — ¿Traes tu Palantír?
- AskUserQuestion antes de iniciar el análisis
- Sin Palantír → análisis estándar (Pasos 1–5)
- Con Palantír → análisis extendido (+ Paso 6)

### Paso 6 — Análisis cruzado con Palantír
- WebFetch condicional a `https://code.claude.com/docs/en/memory`
- Lee CLAUDE.md global, CLAUDE.md proyecto, rules/, memory/
- Detecta **colisiones** 🔴: instrucciones que se contradicen entre configs y skills
- Detecta **redundancias** 🟡: instrucciones en configs ya cubiertas por skills
- Analiza **pertinencia** 🔵: skills vs stack y scope del proyecto
- Verifica **calidad de instalación** 🟢

Closes #227