### PR TITLE
fix(bardo): guía y docs generadas exclusivamente desde WebFetch de docs oficiales

### DIFF
--- a/prompts/bardo/sections/01-module-guide.md
+++ b/prompts/bardo/sections/01-module-guide.md
@@ -25,7 +25,17 @@ basados en el stack detectado del proyecto.
 > **WebFetch 3**: `https://code.claude.com/docs/en/discover-plugins`
 > **Extraer**: catálogo de plugins disponibles, descripciones, compatibilidad.
 
-**Fallback si WebFetch falla**: Continuar con conocimiento interno marcando con ⚠️.
+**Fallback si WebFetch falla**: NO usar conocimiento interno. Mostrar:
+```
+⚠️ No se pudo cargar la documentación oficial en este momento.
+   Las explicaciones requieren las docs oficiales de Claude Code.
+
+   Puedes consultarlas directamente:
+     🔗 MCP:              https://code.claude.com/docs/en/mcp
+     🔌 Plugins:          https://code.claude.com/docs/en/plugins
+     🔍 Discover plugins: https://code.claude.com/docs/en/discover-plugins
+```
+→ Ofrecer AskUserQuestion: reintentar WebFetch / volver al menú.
 
 ---
 
@@ -127,6 +137,10 @@ Si hay más de 2 ítems, paginar (máx 4 opciones por pantalla incluyendo "Ver m
 ---
 
 ## Paso 5 — Asistencia en profundidad
+
+**CRÍTICO**: Todo el contenido de las explicaciones debe extraerse de la documentación oficial
+cargada en el Paso 0 (WebFetch). No generar descripciones, capacidades ni ejemplos desde
+conocimiento interno — usar exclusivamente lo obtenido de las docs oficiales de Claude Code.
 
 Para cada ítem seleccionado, presentar:
 

--- a/prompts/bardo/sections/04-module-docs.md
+++ b/prompts/bardo/sections/04-module-docs.md
@@ -77,9 +77,14 @@ Puedes consultarla directamente:
 
 ## Paso 3 — Generar resumen según nivel
 
+**CRÍTICO**: Los resúmenes de los tres niveles deben construirse **exclusivamente** a partir
+del contenido extraído por WebFetch en el Paso 2. No usar conocimiento interno para generar
+el contenido. Si el WebFetch falló, mostrar solo el bloque de fallback del Paso 2 y no
+intentar resumir desde conocimiento propio.
+
 ### 📖 El grimorio completo
 
-Presentar el contenido completo extraído, organizado en capítulos con lore épico:
+Presentar el contenido completo extraído via WebFetch, organizado en capítulos con lore épico:
 
 ```
 🏹 CAPÍTULO I — El Protocolo MCP: Servidores del Exterior
@@ -97,7 +102,7 @@ Presentar el contenido completo extraído, organizado en capítulos con lore ép
 
 ### ⚡ El resumen del Arquero (5 minutos)
 
-Incluir únicamente:
+Construir a partir del contenido de WebFetch. Incluir únicamente:
 - Qué es un MCP y para qué sirve (2-3 líneas)
 - Qué es un plugin y en qué se diferencia del MCP (2-3 líneas)
 - Dónde se configuran los MCPs: `~/.claude.json` (user) y `.mcp.json` (project)
@@ -107,7 +112,7 @@ Incluir únicamente:
 
 ### 🕐 La nota del Hobbit (2 minutos)
 
-Solo lo imprescindible:
+Construir a partir del contenido de WebFetch. Solo lo imprescindible:
 - Una frase: qué es un MCP
 - Una frase: qué es un plugin y cuándo elegir uno sobre el otro
 - Dónde va la config MCP: `~/.claude.json` (global) / `.mcp.json` (proyecto)


### PR DESCRIPTION
## Summary

- **01-module-guide**: fallback de WebFetch ya no usa conocimiento interno — muestra las URLs y ofrece reintentar; Paso 5 marcado con CRÍTICO: todo el contenido viene de docs oficiales
- **04-module-docs**: los tres niveles (grimorio / 5 min / 2 min) construidos exclusivamente desde WebFetch; si falla, solo se muestran URLs, no se genera resumen

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)