### PR TITLE
feat(quality-sprint): refactoring cross-épica de calidad v4.2.0

### DIFF
--- a/prompts/aragorn/aragorn-main.md
+++ b/prompts/aragorn/aragorn-main.md
@@ -14,9 +14,11 @@
 **SIEMPRE** mostrar este banner al iniciar Aragorn:
 
 ```
-╔═══════════════════════════════════════════════════════════════╗
-║          👑 ARAGORN — El Gestor de Agentes y Subagentes       ║
-╚═══════════════════════════════════════════════════════════════╝
+══════════════════════════════════════════════════════════════
+  ᚨᚱᚨᚷᚩᚱᚾ  👑  ARAGORN — El Rey que Regresa  ᚨᚱᚨᚷᚩᚱᚾ
+══════════════════════════════════════════════════════════════
+    Gestor de Agentes y Subagentes · TLOTP {VERSION}
+──────────────────────────────────────────────────────────────
 
   "No pido la vida de ningún hombre que no quiera dármela.
    Pero hay esperanza. Si el valor no nos falta."
@@ -29,6 +31,8 @@
 
   Cada agente: un guerrero de una raza diferente, forjado
   para una misión concreta. Tú eres el Elessar — convócalos.
+
+══════════════════════════════════════════════════════════════
 ```
 
 ---

--- a/prompts/aragorn/sections/04-module-docs.md
+++ b/prompts/aragorn/sections/04-module-docs.md
@@ -138,7 +138,27 @@ Construir a partir del contenido de WebFetch. Solo lo imprescindible:
     Úsalo bien en la Tierra Media, señor."
 ```
 
-Al finalizar, volver al menú principal de Aragorn (sin repetir banner ni permisos).
+**Tras mostrar el contenido**, preguntar al usuario:
+
+```json
+{
+  "questions": [{
+    "header": "Aragorn · Los Pergaminos del Rey",
+    "question": "👑 ¿Qué deseas hacer ahora, señor?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🔙 Volver al menú de Aragorn",
+        "description": "Regresar a Gondor"
+      },
+      {
+        "label": "🔙 Volver a La Comunidad del Código",
+        "description": "Regresar al menú principal de TLOTP"
+      }
+    ]
+  }]
+}
+```
 
 ---
 

--- a/prompts/bardo/bardo-main.md
+++ b/prompts/bardo/bardo-main.md
@@ -68,33 +68,25 @@ de bienvenida y enrutar al módulo correspondiente.
 
 **CRÍTICO**: Antes del menú, solicitar aprobación con `AskUserQuestion`:
 
+```json
+{
+  "questions": [{
+    "header": "Bardo · Permisos",
+    "question": "🏹 Bardo necesita los siguientes permisos para preparar el arsenal:\n\n  🖥️ Bash — cat, ls (leer configs de MCPs y plugins)\n  📖 Read — ~/.claude.json · .mcp.json · .claude/settings.json\n  🔍 Glob — Buscar archivos de configuración\n  📝 Write — Instalar MCPs y plugins\n  ✏️ Edit — Modificar configuraciones existentes\n  🌐 WebFetch — Documentación oficial on-demand\n\n¿Apruebas los permisos del Arquero?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Aprobar todos",
+        "description": "Bardo trabajará sin interrupciones durante toda la sesión"
+      },
+      {
+        "label": "🚫 Cancelar",
+        "description": "Volver a Lake-town sin entrar"
+      }
+    ]
+  }]
+}
 ```
-🏹 Bardo necesita los siguientes permisos para preparar el arsenal
-
-  🖥️  Bash     — cat, ls (leer configs de MCPs y plugins)
-                  node (verificar entorno si aplica)
-
-  📖  Read     — Configuraciones MCP:
-                  ~/.claude.json · .mcp.json · .claude/settings.json
-                  Configuraciones del proyecto (stack detection)
-
-  🔍  Glob     — Buscar archivos de configuración en el proyecto
-
-  📝  Write    — Instalar MCPs (editar ~/.claude.json o .mcp.json)
-                  Instalar plugins
-
-  ✏️  Edit     — Modificar configuraciones existentes de MCPs y plugins
-
-  🌐  WebFetch — Documentación oficial on-demand (nunca precargada):
-                  docs/en/mcp · docs/en/plugins · docs/en/discover-plugins
-                  docs/en/plugin-marketplaces
-
-¿Apruebas los permisos del Arquero?
-```
-
-**Opciones** (AskUserQuestion):
-1. **✅ Aprobar todos** — Bardo trabajará sin interrupciones durante toda la sesión
-2. **🚫 Cancelar** — Volver a Lake-town sin entrar
 
 - **Aprobar todos**: Registrar permisos. Continuar al menú.
 - **Cancelar**: `"🏹 Que tu camino sea recto, viajero."` y terminar.

--- a/prompts/bardo/sections/08-el-trovador.md
+++ b/prompts/bardo/sections/08-el-trovador.md
@@ -174,9 +174,27 @@ Si hay MCPs o plugins cuya documentación no pudo obtenerse ni está en el conoc
 
 ### Paso 6 — Volver al menú
 
-Tras mostrar toda la guía, pregunta al usuario (AskUserQuestion):
-- Volver al menú de Bardo
-- Salir
+Tras mostrar toda la guía, preguntar al usuario:
+
+```json
+{
+  "questions": [{
+    "header": "Bardo · El Trovador",
+    "question": "🏹 ¿Qué deseas hacer ahora, señor del Fuerte?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🔙 Volver al menú de Bardo",
+        "description": "Regresar a Lake-town"
+      },
+      {
+        "label": "🔙 Volver a La Comunidad del Código",
+        "description": "Regresar al menú principal de TLOTP"
+      }
+    ]
+  }]
+}
+```
 
 ---
 

--- a/prompts/celebrimbor/README.md
+++ b/prompts/celebrimbor/README.md
@@ -10,10 +10,7 @@
 
 ## 🎯 ¿Qué es Celebrimbor?
 
-Sistema de gestión de skills para Claude Code que ofrece **dos modos de operación**:
-
-- ⚡ **Backend CLI** (Node.js >=18) - ✅ Operativo
-- 📦 **Backend Git** (universal) - 🚧 Planificado
+Sistema de gestión de skills para Claude Code con CRUD completo vía CLI de inference.sh.
 
 ---
 
@@ -53,29 +50,30 @@ prompts/celebrimbor/
 └── sections/
     ├── 01-detector-entorno.md       # Detección Node.js ✅
     ├── 02-menu-principal.md         # Menú interactivo ✅
-    ├── 03-backend-cli.md            # Backend CLI (WIP)
-    ├── 04-backend-git.md            # Backend Git (v2.2.0)
-    └── 05-modo-automatico.md        # Modo automático (futuro)
+    ├── 04-backend-cli.md            # Backend CLI operativo ✅
+    ├── 07-module-analyze.md         # Análisis de skills ✅
+    ├── 07-module-search.md          # Búsqueda de skills ✅
+    ├── 08-module-install.md         # Instalación ✅
+    ├── 09-module-list.md            # Listado ✅
+    ├── 10-module-remove.md          # Eliminación ✅
+    ├── 11-module-update.md          # Actualización ✅
+    ├── 12-module-create-skill.md    # Creación asistida ✅
+    ├── 13-module-docs.md            # Documentación oficial ✅
+    └── 14-skills-cli-reference.md   # Referencia CLI ✅
 ```
 
 ---
 
-## 📋 Progreso del Desarrollo
+## 📋 Estado del Desarrollo
 
-### Tarea #1: Setup y Detección ✅
-- [x] Detección de Node.js
-- [x] Validación de requisitos
-- [x] Reporte de estado
-- [x] Documentación de requisitos
-
-### Tarea #2: Arquitectura Modular (WIP)
-- [ ] Interfaz común
-- [ ] Backend CLI (implementar)
-- [ ] Backend Git (hooks)
-- [ ] Sistema de selección
-
-### Tareas #3-#13: (Pendientes)
-Ver issue #42 para detalles completos
+### ✅ CRUD Completo — Backend CLI Operativo
+- [x] Detección de Node.js y requisitos
+- [x] Menú principal interactivo
+- [x] Backend CLI con inference.sh
+- [x] Buscar, instalar, listar, eliminar, actualizar skills
+- [x] Creación asistida de skills personalizadas
+- [x] Documentación oficial integrada
+- [x] Referencia CLI completa
 
 ---
 

--- a/prompts/celebrimbor/sections/02-menu-principal.md
+++ b/prompts/celebrimbor/sections/02-menu-principal.md
@@ -35,34 +35,25 @@ Gestionar el entry point de Celebrimbor: pedir permisos, mostrar el menú y enru
 
 **CRÍTICO**: Antes del menú, solicitar aprobación con `AskUserQuestion`:
 
+```json
+{
+  "questions": [{
+    "header": "Celebrimbor · Permisos",
+    "question": "⚒️ Celebrimbor necesita los siguientes permisos:\n\n  🖥️ Bash — npx skills (check/find/add/update/remove/list)\n  📖 Read — ~/.claude/skills/ · .claude/skills/ · CLAUDE.md · rules/\n  🔍 Glob — Buscar archivos SKILL.md en rutas globales y locales\n  📝 Write — Instalar y crear skills\n  ✏️ Edit — Mejorar y actualizar skills existentes\n  🌐 WebFetch — Documentación oficial on-demand\n\n¿Apruebas los permisos de la Forja?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Aprobar todos",
+        "description": "Celebrimbor trabajará sin interrupciones durante toda la sesión"
+      },
+      {
+        "label": "🚫 Cancelar",
+        "description": "Salir de Eregion"
+      }
+    ]
+  }]
+}
 ```
-⚒️ Celebrimbor necesita los siguientes permisos
-
-  🖥️  Bash     — npx skills (check/find/add/update/remove/list)
-                  nvm/node (verificar entorno)
-                  rm (eliminar skills sin CLI), mkdir
-
-  📖  Read     — Skills instaladas (~/.claude/skills/, .claude/skills/)
-                  Configuraciones del sistema (si usas Palantír):
-                  ~/.claude/CLAUDE.md · ~/.claude/rules/ · ~/.claude/memory/
-                  ./CLAUDE.md · ./.claude/rules/
-
-  🔍  Glob     — Buscar archivos SKILL.md en rutas globales y locales
-
-  📝  Write    — Instalar y crear skills
-                  (~/.claude/skills/, .claude/skills/)
-
-  ✏️  Edit     — Mejorar y actualizar skills existentes
-
-  🌐  WebFetch — Documentación oficial on-demand (nunca precargada):
-                  skills · skills.sh · memoria/configuración
-
-¿Apruebas los permisos de la Forja?
-```
-
-**Opciones** (AskUserQuestion):
-1. **✅ Aprobar todos** — Celebrimbor trabajará sin interrupciones durante toda la sesión
-2. **🚫 Cancelar** — Salir de Eregion
 
 - **Aprobar todos**: Registrar permisos. Continuar al menú.
 - **Cancelar**: Mostrar despedida épica y terminar.

--- a/prompts/gandalf/gandalf-main.md
+++ b/prompts/gandalf/gandalf-main.md
@@ -14,10 +14,11 @@
 **SIEMPRE** mostrar este banner al iniciar Gandalf:
 
 ```
-╔═══════════════════════════════════════════════════════════════╗
-║       ⚡ GANDALF — El Antídoto al Vibe Coding                ║
-║       Spec-Driven Development — La Comunidad del Código      ║
-╚═══════════════════════════════════════════════════════════════╝
+══════════════════════════════════════════════════════════════
+  ᚷᚨᚾᛞᚨᛚᚠ  ⚡  GANDALF — El Mago Blanco  ᚷᚨᚾᛞᚨᛚᚠ
+══════════════════════════════════════════════════════════════
+    Spec-Driven Development · TLOTP {VERSION}
+──────────────────────────────────────────────────────────────
 
   "Un mago nunca llega tarde, ni pronto.
    Llega exactamente cuando lo decide... y con el mapa ya hecho."
@@ -45,6 +46,8 @@
 
   Sin especificación no hay expedición. Sin mapa no hay victoria.
   El vibe coding es el Camino de los Muertos — nadie regresa.
+
+══════════════════════════════════════════════════════════════
 ```
 
 ---

--- a/prompts/palantir/sections/00-docs-official.md
+++ b/prompts/palantir/sections/00-docs-official.md
@@ -1,0 +1,33 @@
+# 📚 Documentación Oficial Claude Code — Módulo Centralizado
+
+> **IMPORTADO POR**: 03-jerarquia-oficial.md, 05-susurrar-planes.md, 06-compartir-visiones.md
+> **NO contiene lógica de negocio ni routing** — solo instrucciones de fetch.
+>
+> **Caching de sesión**: Si en esta sesión ya se hizo WebFetch a estas URLs,
+> reutilizar ese contenido directamente sin refetchear.
+
+---
+
+## Documentación Oficial (Live)
+
+Obtener documentación actualizada en este orden:
+
+> **WebFetch 1**: https://code.claude.com/docs/en/how-claude-code-works
+> **Extraer**: arquitectura general, cómo se cargan CLAUDE.md y MEMORY.md, extension points
+
+> **WebFetch 2**: https://code.claude.com/docs/en/best-practices
+> **Extraer**: criterios de buenas prácticas (límite 200 líneas CLAUDE.md, qué incluir/excluir, estructura recomendada)
+
+> **WebFetch 3**: https://code.claude.com/docs/en/memory
+> **Extraer**: tabla completa de tipos de memoria, jerarquía de precedencia, estructura de auto memory, sistema de rules con paths, sistema de @imports
+
+> **WebFetch 4**: https://code.claude.com/docs/en/settings
+> **Extraer**: jerarquía de settings (Managed > User > Project > Local), ubicaciones de ficheros, permisos disponibles
+
+> **WebFetch 5**: https://code.claude.com/docs/en/hooks
+> **Extraer**: eventos disponibles, schema de configuración, tipos de hooks, patrones de matcher
+
+> **WebFetch 6**: https://code.claude.com/docs/en/features-overview
+> **Extraer**: cuándo usar cada feature (CLAUDE.md vs skills vs hooks vs subagents), costes de contexto
+
+**Usar la información obtenida como fuente de verdad** para todos los análisis y operaciones del módulo que importa este fichero.

--- a/prompts/palantir/sections/00-menu-principal.md
+++ b/prompts/palantir/sections/00-menu-principal.md
@@ -21,7 +21,7 @@
 ═══════════════════════════════════════════════════════════════════════
 ```
 
-**IMPORTANTE**: Reemplaza `{VERSION}` con la versión actual de TLOTP cargada desde `@prompts/VERSION.md` (actualmente v2.1.0)
+**IMPORTANTE**: Reemplaza `{VERSION}` con la versión actual de TLOTP cargada desde `@prompts/VERSION.md`
 
 ---
 

--- a/prompts/palantir/sections/03-jerarquia-oficial.md
+++ b/prompts/palantir/sections/03-jerarquia-oficial.md
@@ -2,27 +2,9 @@
 
 ## 📖 Documentación Oficial (Live)
 
-**ANTES de ejecutar la inspección**, obtener documentación actualizada en este orden:
+**ANTES de ejecutar la inspección**, obtener documentación actualizada:
 
-> **WebFetch 1**: https://code.claude.com/docs/en/how-claude-code-works
-> **Extraer**: arquitectura general, cómo se cargan CLAUDE.md y MEMORY.md, extension points
-
-> **WebFetch 2**: https://code.claude.com/docs/en/best-practices
-> **Extraer**: criterios de buenas prácticas (límite 200 líneas CLAUDE.md, qué incluir/excluir, estructura recomendada)
-
-> **WebFetch 3**: https://code.claude.com/docs/en/memory
-> **Extraer**: tabla completa de tipos de memoria, jerarquía de precedencia, estructura de auto memory, sistema de rules con paths, sistema de @imports
-
-> **WebFetch 4**: https://code.claude.com/docs/en/settings
-> **Extraer**: jerarquía de settings (Managed > User > Project > Local), ubicaciones de ficheros, permisos disponibles
-
-> **WebFetch 5**: https://code.claude.com/docs/en/hooks
-> **Extraer**: eventos disponibles, schema de configuración, tipos de hooks, patrones de matcher
-
-> **WebFetch 6**: https://code.claude.com/docs/en/features-overview
-> **Extraer**: cuándo usar cada feature (CLAUDE.md vs skills vs hooks vs subagents), costes de contexto
-
-**Usar la información obtenida como fuente de verdad** para todos los niveles de inspección y análisis.
+@prompts/palantir/sections/00-docs-official.md
 
 ---
 

--- a/prompts/palantir/sections/05-susurrar-planes.md
+++ b/prompts/palantir/sections/05-susurrar-planes.md
@@ -25,31 +25,7 @@ Obtener input libre del usuario.
 
 ## PASO 2: Cargar documentación oficial
 
-**Comprobar primero** si la documentación oficial ya está cargada en el contexto
-de esta sesión (por haber ejecutado previamente "Contemplar el reino" u otro módulo
-que haya hecho los WebFetch).
-
-**Si ya está en contexto**: usar directamente esa información sin re-fetchear.
-
-**Si no está en contexto**, obtener documentación en este orden:
-
-> **WebFetch 1**: https://code.claude.com/docs/en/how-claude-code-works
-> **Extraer**: arquitectura general, cómo se cargan los ficheros de configuración
-
-> **WebFetch 2**: https://code.claude.com/docs/en/best-practices
-> **Extraer**: criterios de buenas prácticas, qué va en cada fichero, límites
-
-> **WebFetch 3**: https://code.claude.com/docs/en/memory
-> **Extraer**: tipos de memoria, jerarquía de precedencia, rules con paths, @imports
-
-> **WebFetch 4**: https://code.claude.com/docs/en/settings
-> **Extraer**: jerarquía de settings, ubicaciones, permisos disponibles
-
-> **WebFetch 5**: https://code.claude.com/docs/en/hooks
-> **Extraer**: eventos, schema de configuración, tipos de hooks, matchers
-
-> **WebFetch 6**: https://code.claude.com/docs/en/features-overview
-> **Extraer**: cuándo usar cada feature, costes de contexto, qué va dónde
+@prompts/palantir/sections/00-docs-official.md
 
 ---
 
@@ -99,7 +75,7 @@ Con la petición del usuario y la documentación oficial, razonar en profundidad
 ```json
 {
   "questions": [{
-    "header": "Análisis",
+    "header": "Palantír · Análisis",
     "question": "¿Cómo deseas proceder?",
     "multiSelect": false,
     "options": [
@@ -114,6 +90,10 @@ Con la petición del usuario y la documentación oficial, razonar en profundidad
       {
         "label": "✏️ Ajustar manualmente",
         "description": "Modificar la propuesta antes de continuar"
+      },
+      {
+        "label": "🔎 Buscar alternativa en docs",
+        "description": "Releer la documentación oficial y proponer una solución alternativa"
       }
     ]
   }]

--- a/prompts/palantir/sections/06-compartir-visiones.md
+++ b/prompts/palantir/sections/06-compartir-visiones.md
@@ -67,27 +67,7 @@
 
 ### PASO 2: Cargar documentación oficial (condicional)
 
-Comprobar si la documentación oficial ya está en contexto de esta sesión.
-
-**Si no está en contexto**, obtener en este orden:
-
-> **WebFetch 1**: https://code.claude.com/docs/en/how-claude-code-works
-> **Extraer**: arquitectura general, cómo se cargan los ficheros de configuración
-
-> **WebFetch 2**: https://code.claude.com/docs/en/best-practices
-> **Extraer**: criterios de buenas prácticas, qué va en cada fichero, límites
-
-> **WebFetch 3**: https://code.claude.com/docs/en/memory
-> **Extraer**: tipos de memoria, jerarquía de precedencia, rules con paths, @imports
-
-> **WebFetch 4**: https://code.claude.com/docs/en/settings
-> **Extraer**: jerarquía de settings, ubicaciones, permisos disponibles
-
-> **WebFetch 5**: https://code.claude.com/docs/en/hooks
-> **Extraer**: eventos, schema de configuración, tipos de hooks, matchers
-
-> **WebFetch 6**: https://code.claude.com/docs/en/features-overview
-> **Extraer**: cuándo usar cada feature, costes de contexto, qué va dónde
+@prompts/palantir/sections/00-docs-official.md
 
 ---
 

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -141,8 +141,7 @@ Nunca actúa sin confirmación.
 
 ⚔️ **⚡ Gandalf** — El Mago Blanco. Spec-Driven Development.
    *(SDD interactivo: requirements.md · design.md · tasks.md)*
-💍 **Gollum** vive dentro de **Aragorn** — el Rey lo invoca por proyecto.
-   *(opción "Llamar a Gollum" en Aragorn · .claude/agents/gollum.md · siempre project-scoped)*
+💍 **Gollum** — Companion de testing *(planificado · no disponible aún)*
 
 ---
 
@@ -297,7 +296,7 @@ para hacerlo lo más autónomo posible.
    Estado: Completado
 
 ✅ ⚡ Gandalf - Spec-Driven Development (SDD interactivo completo)
-🔧 💍 Gollum - Agente de Release y Testing por Proyecto (vive dentro de Aragorn · issue #281)
+💭 💍 Gollum - Companion de testing (planificado · no disponible aún)
 
 ---
 


### PR DESCRIPTION
## Summary

- **T01/T02**: Centraliza las 6 URLs WebFetch de Palantír en `00-docs-official.md` y elimina la triple duplicación en módulos 03, 05 y 06
- **T03**: Banners rúnicos Elder Futhark (═══ + ᚱᚢᚾᛖᛋ) en `aragorn-main.md` y `gandalf-main.md` — coherencia visual cross-épica
- **T04**: Bloques de retorno `AskUserQuestion` en módulos terminales (`bardo/08-el-trovador`, `aragorn/04-module-docs`)
- **T05**: Opción "🔎 Buscar alternativa en docs" en el revisor de `05-susurrar-planes`
- **T06**: Elimina versión hardcodeada `v2.1.0` de `palantir/00-menu-principal`; corrige estructura real de módulos en `celebrimbor/README.md`
- **T07**: Unifica patrón de permisos (AskUserQuestion JSON directo) en Bardo y Celebrimbor
- **T08**: Marca Gollum como `planificado · no disponible aún` en `tlotp-main.md`
- **T09**: Validación cross-épica — 0 WebFetch duplicados, @imports resueltos, banners y retornos consistentes

Closes #293

## Test plan

- [ ] Verificar que `00-docs-official.md` existe y los módulos 03, 05 y 06 lo importan con `@import`
- [ ] Verificar que ninguno de los 3 módulos tiene WebFetch directos a las 6 URLs centralizadas
- [ ] Confirmar banner rúnico visible en Aragorn y Gandalf (borde ═══ + caracteres Elder Futhark)
- [ ] Confirmar que `08-el-trovador` y `04-module-docs` tienen bloque AskUserQuestion de retorno al final
- [ ] Confirmar que `palantir/00-menu-principal.md` no contiene `v2.1.0` hardcodeado
- [ ] Confirmar que `celebrimbor/README.md` lista solo módulos que existen en disco
- [ ] Confirmar que Bardo y Celebrimbor usan AskUserQuestion JSON para permisos
- [ ] Confirmar que tlotp-main no promete "Llamar a Gollum" sin implementación

🤖 Generated with [Claude Code](https://claude.com/claude-code)