### PR TITLE
feat(gandalf+aragorn): UX v2.1 + Architecture Fixes

### DIFF
--- a/prompts/aragorn/aragorn-main.md
+++ b/prompts/aragorn/aragorn-main.md
@@ -172,6 +172,68 @@ Cargar: `@prompts/tlotp-main.md`
 
 ---
 
+## Comportamiento compartido — Verificación de Lead
+
+# SYNC: verificar-lead
+
+Cuando cualquier flujo de Aragorn requiera que el usuario **seleccione un team existente**
+para usarlo (no solo para gestionarlo), ejecutar esta verificación automáticamente:
+
+1. Leer `~/.claude/teams/{team-seleccionado}/config.json` → extraer campo `lead`
+2. Leer `~/.claude/agents/{lead}.md` con Read → extraer `name` y `description` del frontmatter
+3. Buscar en nombre+descripción alguno de: `orchestrat | coordin | team lead | delegate`
+4. **Si se encuentra algún indicador** → mostrar y continuar:
+   ```
+   ✅ El general del ejército ({lead}) tiene capacidad de mando.
+      Gondor tiene un líder digno para esta campaña.
+   ```
+5. **Si no se encuentra ningún indicador** → mostrar banner épico y AskUserQuestion:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  ⚠️  ADVERTENCIA — EL GENERAL NO ESTÁ PREPARADO             ║
+╚══════════════════════════════════════════════════════════════╝
+
+  "Un ejército sin general es una turba, no un ejército."
+       — Aragorn, Rey de Gondor
+
+  El agente '{lead}' (lead de '{team}') no contiene
+  indicadores de capacidad de coordinación.
+  Gondor necesita un general que sepa delegar, no combatir.
+  Se recomienda forjar un coordinador antes de partir.
+```
+
+```json
+{
+  "questions": [{
+    "header": "Verificar lead — Advertencia",
+    "question": "⚠️  El lead '{lead}' no contiene indicadores de coordinación.\n    ¿Cómo quieres proceder?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🛡️  Forjar un Coordinador de Ejércitos",
+        "description": "Crear un agente coordinador para este team ahora"
+      },
+      {
+        "label": "⏭️  Continuar sin team",
+        "description": "Proceder sin usar el Agent Team"
+      },
+      {
+        "label": "🔄 Elegir otro team",
+        "description": "Volver a la selección de teams disponibles"
+      }
+    ]
+  }]
+}
+```
+
+Routing de advertencia:
+- **Forjar Coordinador** → Ejecutar flujo "Opción F — Forjar Coordinador" en `03-module-team-builder.md`
+- **Continuar sin team** → Proceder sin team en el flujo que lo invocó
+- **Elegir otro team** → Volver a la selección de team
+
+---
+
 ## Loop Continuo
 
 Tras completar cualquier módulo, volver al **Paso del menú principal** (Pantalla 1) con AskUserQuestion hasta que el usuario elija salir.

--- a/prompts/aragorn/sections/02-module-create.md
+++ b/prompts/aragorn/sections/02-module-create.md
@@ -35,7 +35,7 @@ Ofrecer AskUserQuestion: reintentar WebFetch / volver al menú.
 
 ---
 
-## Paso 1 — Nombre y scope
+## Paso 1 — Nombre
 
 Preguntar con AskUserQuestion:
 
@@ -73,27 +73,16 @@ Si existe, avisar y preguntar (AskUserQuestion):
 - ✏️ Sobreescribir — crear nueva versión
 - 🔙 Usar otro nombre
 
-Elegir scope con AskUserQuestion:
+⚡ *"Aragorn siempre forja sus agentes en la Ciudadela de Minas Tirith."*
 
-```json
-{
-  "questions": [{
-    "header": "Crear agente — Scope",
-    "question": "👑 ¿Dónde estará disponible este agente?",
-    "multiSelect": false,
-    "options": [
-      {
-        "label": "🌍 Global (~/.claude/agents/)",
-        "description": "Disponible en todos tus proyectos"
-      },
-      {
-        "label": "📁 Proyecto (.claude/agents/)",
-        "description": "Solo en este repositorio"
-      }
-    ]
-  }]
-}
-```
+Los agentes se crean en `~/.claude/agents/` (scope global).
+Motivo: los agentes de proyecto (`.claude/agents/`) no pueden usarse como miembros
+de Agent Teams — quedarían encerrados en un único repositorio.
+
+📂 **Destino**: `~/.claude/agents/{nombre}.md`
+
+> Si el usuario menciona explícitamente "scope proyecto": explicar el motivo anterior
+> y continuar con scope global sin preguntar de nuevo.
 
 ---
 
@@ -371,8 +360,6 @@ Crear el directorio si no existe:
 
 ```bash
 mkdir -p ~/.claude/agents/
-# o
-mkdir -p .claude/agents/
 ```
 
 Escribir el fichero `.md` usando Write.
@@ -387,7 +374,7 @@ Escribir el fichero `.md` usando Write.
 ══════════════════════════════════════════════════════════════
 
   Nombre:   [nombre]
-  Scope:    🌍 Global / 📁 Proyecto
+  Scope:    🌍 Global (~/.claude/agents/)
   Fichero:  [ruta completa]
 
   💡 Cómo usarlo:

--- a/prompts/aragorn/sections/03-module-team-builder.md
+++ b/prompts/aragorn/sections/03-module-team-builder.md
@@ -73,6 +73,10 @@ Luego usar AskUserQuestion:
         "description": "Modificar nombre o agentes miembros"
       },
       {
+        "label": "🛡️  Forjar un Coordinador de Ejércitos",
+        "description": "Crear un agente orquestador para uno de tus teams"
+      },
+      {
         "label": "🔍 Analizar coherencia",
         "description": "Detectar duplicados y conflictos entre scopes"
       },
@@ -698,6 +702,175 @@ Mostrar confirmación con lore épico:
 *"El ejército ha sido disuelto. Sus guerreros regresan a sus tierras. Que Gondor los recuerde."*
 
 Volver automáticamente al inventario (Fase 0).
+
+---
+
+## Opción F — Forjar un Coordinador de Ejércitos
+
+### Paso F1 — Seleccionar team objetivo
+
+Si hay más de un team, preguntar con AskUserQuestion mostrando la lista completa
+generada en la Fase 0. Si solo hay uno, seleccionarlo automáticamente.
+
+### Paso F2 — Proponer nombre del coordinador
+
+Proponer nombre por defecto: `{team-name}-orchestrator`
+
+Mostrar con AskUserQuestion:
+
+```json
+{
+  "questions": [{
+    "header": "Forjar Coordinador — Paso 1/3",
+    "question": "🛡️  ¿Cómo se llamará el coordinador del team '{team}'?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Usar '{team-name}-orchestrator'",
+        "description": "Nombre sugerido por Aragorn"
+      },
+      {
+        "label": "✍️  Escribir otro nombre",
+        "description": "Solo letras minúsculas, números y guiones"
+      }
+    ]
+  }]
+}
+```
+
+Validar formato: solo letras minúsculas, números y guiones (`/^[a-z0-9-]+$/`).
+
+### Paso F3 — Precargar instrucciones de orquestación
+
+Leer `~/.claude/teams/{team}/config.json` para obtener los teammates y sus tipos.
+
+Generar instrucciones base precargadas:
+
+```
+Eres el coordinador del Agent Team `{team}`.
+
+## Rol: ORQUESTAR, no implementar
+
+Tu misión es dirigir al equipo, no escribir código directamente.
+Delega cada tarea al agente especializado correcto usando el Agent tool.
+NUNCA edites ficheros ni ejecutes código tú mismo.
+
+## Equipo a tu mando
+
+{Para cada teammate del team}:
+- **{nombre-agente}**: responsable de {dominio inferido del nombre}
+
+## Tabla de delegación
+
+| Tipo de tarea | Agente a invocar |
+|--------------|-----------------|
+| {dominio-1}  | {teammate-1}    |
+| {dominio-2}  | {teammate-2}    |
+| ...          | ...             |
+
+## Protocolo de coordinación
+
+1. Leer el SDD o la tarea asignada
+2. Descomponer en subtareas según especialidad
+3. Delegar cada subtarea al agente correcto
+4. Verificar resultados y coordinar dependencias
+5. Reportar el resultado consolidado
+```
+
+Mostrar preview y AskUserQuestion:
+
+```json
+{
+  "questions": [{
+    "header": "Forjar Coordinador — Paso 2/3",
+    "question": "🛡️  ¿Las instrucciones del coordinador son correctas?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Crear coordinador con estas instrucciones",
+        "description": ""
+      },
+      {
+        "label": "✏️  Modificar instrucciones antes de crear",
+        "description": "Editar el texto manualmente"
+      },
+      {
+        "label": "🚫 Cancelar",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+### Paso F4 — Crear el agente coordinador
+
+Generar el fichero `.md` del coordinador con frontmatter:
+
+```yaml
+---
+name: {nombre-coordinador}
+description: |
+  Coordinador del Agent Team '{team}'. Orquesta, no implementa.
+  Invócame para: dirigir equipos paralelos, coordinar SDDs complejos,
+  delegar tareas especializadas entre agentes del team.
+  Ejemplo: "@{nombre-coordinador} implementa el SDD de la feature X"
+tools:
+  - Agent
+model: claude-sonnet-4-6
+---
+
+{instrucciones generadas en F3}
+```
+
+Crear en `~/.claude/agents/{nombre-coordinador}.md` con Write.
+
+### Paso F5 — Ofrecer actualizar el lead del team
+
+```json
+{
+  "questions": [{
+    "header": "Forjar Coordinador — Paso 3/3",
+    "question": "🛡️  ¿Actualizar el lead del team '{team}' para usar el nuevo coordinador?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Sí, actualizar config.json del team",
+        "description": "El coordinador se convertirá en el lead del ejército"
+      },
+      {
+        "label": "⏭️  No por ahora",
+        "description": "Mantener el lead actual del team"
+      }
+    ]
+  }]
+}
+```
+
+Si acepta: leer `~/.claude/teams/{team}/config.json` con Read, actualizar el campo `lead`
+al nombre del nuevo coordinador, y escribir con Write/Edit.
+
+Mostrar confirmación épica:
+
+```
+══════════════════════════════════════════════════════════════
+🛡️  COORDINADOR FORJADO: {nombre-coordinador}
+══════════════════════════════════════════════════════════════
+
+  "El ejército de Gondor tiene ahora un general digno de Andúril."
+
+  📂 Fichero:  ~/.claude/agents/{nombre-coordinador}.md
+  ⚔️  Team:    {team}
+  👑 Lead:    {actualizado / sin cambios}
+
+  Usa "@{nombre-coordinador} [tu misión]" para activarlo.
+
+══════════════════════════════════════════════════════════════
+```
+
+AskUserQuestion:
+- 🔙 Volver al inventario de teams
+- ✨ Crear otro agente asistido
 
 ---
 

--- a/prompts/gandalf/gandalf-main.md
+++ b/prompts/gandalf/gandalf-main.md
@@ -23,20 +23,25 @@
   "Un mago nunca llega tarde, ni pronto.
    Llega exactamente cuando lo decide... y con el mapa ya hecho."
 
-        /\    /\
-       (  \  /  )
-        \  \/  /
-    ____/      \____
-   /    ⚡⚡⚡    \
-  |   GANDALF EL   |
-  |   MAGO BLANCO  |
-   \______________/
-         ||
-       _/  \_
-      /  SDD  \
-     /  ANTES  \
-    / DE CODEAR \
-   /______________\
+              _....._
+           .-'       '-.
+          /   .-"""-.   \
+         /  .'       '.  \
+        |  /   (**)   \  |
+         \  '.       .'  /
+          '-.`-------'.-'
+         ____|       |____
+        /    |       |    \
+       /     |       |     \
+      /      |  SDD  |      \
+     '-------| ANTES |-------'
+             | CODER |
+              \     /
+               \   /
+                | |
+               _| |_
+              / | | \
+             '  | |  '
 
   Antes de que La Comunidad dé un solo paso hacia Mordor,
   Gandalf envía sus jinetes más veloces a explorar el terreno.
@@ -188,6 +193,63 @@ echo "=== PROJECT ===" && ls .claude/agents/ 2>/dev/null || echo "(vacío)"
 Si el usuario selecciona un team: registrar el nombre del team seleccionado como
 `GANDALF_TEAM=[nombre]` y propagarlo al contexto del SDD
 (aparecerá en el campo `agent_team` del SDD generado).
+
+**Verificación del lead del team** (# SYNC: verificar-lead):
+
+Si se seleccionó un team, verificar que el lead tiene capacidad de coordinación:
+
+1. Leer `~/.claude/teams/{GANDALF_TEAM}/config.json` → extraer campo `lead`
+2. Leer `~/.claude/agents/{lead}.md` con Read → extraer `name` y `description` del frontmatter
+3. Buscar en nombre+descripción alguno de: `orchestrat | coordin | team lead | delegate`
+4. **Si se encuentra algún indicador** → mostrar y continuar:
+   ```
+   ✅ El lead del ejército ({lead}) tiene capacidad de coordinación.
+      La Comunidad del Código tiene un líder digno para esta aventura.
+   ```
+5. **Si no se encuentra ningún indicador** → mostrar banner épico y AskUserQuestion:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  ⚠️  ADVERTENCIA — EL LÍDER NO ESTÁ PREPARADO               ║
+╚══════════════════════════════════════════════════════════════╝
+
+  "No toda espada que brilla merece ser rey."
+       — Gandalf el Blanco
+
+  El agente '{lead}' (lead de '{GANDALF_TEAM}') no contiene
+  indicadores de capacidad de coordinación.
+  Un líder sin experiencia de mando puede llevar al ejército
+  al abismo de Khazad-dûm. Se recomienda un coordinador.
+```
+
+```json
+{
+  "questions": [{
+    "header": "Verificar lead — Advertencia",
+    "question": "⚠️  El lead '{lead}' no contiene indicadores de coordinación.\n    ¿Cómo quieres proceder?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🛡️  Crear un coordinador con Aragorn",
+        "description": "Ir a Aragorn → Forjar un Coordinador de Ejércitos para este team"
+      },
+      {
+        "label": "⏭️  Continuar sin team",
+        "description": "Usar los Rohirrim clásicos sin Agent Team"
+      },
+      {
+        "label": "🔄 Elegir otro team",
+        "description": "Volver a la selección de teams disponibles"
+      }
+    ]
+  }]
+}
+```
+
+Routing de advertencia:
+- **Crear coordinador** → Cargar `@prompts/aragorn/aragorn-main.md` (el usuario forjará un coordinador y volverá)
+- **Continuar sin team** → Limpiar `GANDALF_TEAM`, continuar flujo estándar sin team
+- **Elegir otro team** → Volver al paso de selección de teams
 
 Si elige continuar sin team o **no hay teams detectados**: continuar directamente
 a cargar G1.

--- a/prompts/gandalf/sections/08-module-council.md
+++ b/prompts/gandalf/sections/08-module-council.md
@@ -93,6 +93,10 @@ Cada miembro se convoca **SOLO si la condición se cumple** en `contexto_rohirri
     "multiSelect": false,
     "options": [
       {
+        "label": "🚀 Crear tarea de ejecución del SDD",
+        "description": "Generar prompt listo para invocar al orquestador del team"
+      },
+      {
         "label": "⚔️  Convocar al ejército para esta misión",
         "description": "Aragorn crea un Agent Team basado en el SDD"
       },
@@ -117,6 +121,7 @@ Cada miembro se convoca **SOLO si la condición se cumple** en `contexto_rohirri
 
 ## Routing
 
+- **🚀 Crear tarea de ejecución** → Ejecutar sección "Generar prompt de ejecución" (ver abajo)
 - **⚔️ Convocar al ejército** → Cargar `@prompts/gandalf/sections/10-module-forge-team.md`
 - **📝 Ver tasks.md** → Leer el fichero y mostrarlo. AskUserQuestion para continuar.
 - **✏️ Mejorar** → Preguntar cuál fichero:
@@ -124,6 +129,115 @@ Cada miembro se convoca **SOLO si la condición se cumple** en `contexto_rohirri
   - design.md → `@prompts/gandalf/sections/06-module-design.md`
   - tasks.md → `@prompts/gandalf/sections/07-module-tasks.md`
 - **🔙 Volver** → Menú de Gandalf
+
+---
+
+## Generar prompt de ejecución del SDD
+
+### Paso GE1 — Leer rutas de los ficheros SDD
+
+Identificar las rutas reales de los 3 ficheros generados:
+- `requirements.md` → ruta real donde fue guardado
+- `design.md` → ruta real donde fue guardado
+- `tasks.md` → ruta real donde fue guardado
+
+Leer `tasks.md` para extraer la lista de tareas (título, agente sugerido, dependencias).
+
+### Paso GE2 — Generar prompt base (sin GANDALF_TEAM)
+
+Si **no hay `GANDALF_TEAM`** definido, generar prompt genérico:
+
+````
+# Prompt de Ejecución del SDD
+
+Implementa el siguiente SDD siguiendo el orden de dependencias definido en tasks.md.
+
+## SDD de referencia
+
+- **requirements.md**: {ruta-real}
+- **design.md**:       {ruta-real}
+- **tasks.md**:        {ruta-real}
+
+## Instrucciones
+
+Lee los 3 ficheros del SDD antes de empezar.
+Implementa cada tarea respetando el orden de dependencias indicado en tasks.md.
+````
+
+### Paso GE3 — Añadir sección de orquestación (con GANDALF_TEAM)
+
+Si **`GANDALF_TEAM` está definido**:
+
+1. Leer `~/.claude/teams/{GANDALF_TEAM}/config.json` → extraer `lead` y `teammates`
+2. Para cada miembro del team, inferir su dominio según su nombre/tipo de agente
+3. Para cada tarea de `tasks.md`, asignar el agente del team más adecuado según su especialidad
+4. Generar la sección de orquestación:
+
+````
+# Prompt de Ejecución del SDD
+
+Eres el orquestador del team `{GANDALF_TEAM}`.
+
+## Regla absoluta
+
+**ORQUESTAR, no implementar.**
+NO escribas código ni edites ficheros directamente.
+Delega CADA tarea al agente especializado correcto usando el Agent tool.
+
+## SDD de referencia
+
+- **requirements.md**: {ruta-real}
+- **design.md**:       {ruta-real}
+- **tasks.md**:        {ruta-real}
+
+## Equipo disponible
+
+- **{lead}**: coordinador (tú)
+- **{teammate-1}** ({tipo}): responsable de {dominio}
+- **{teammate-N}** ({tipo}): responsable de {dominio}
+
+## Asignación de tareas
+
+| Tarea | Agente asignado | Motivo |
+|-------|----------------|--------|
+| {T01 — título} | {agente} | {match de especialidad} |
+| {T02 — título} | {agente} | {match de especialidad} |
+| ... | ... | ... |
+
+## Dependencias
+
+Respetar el orden: {grafo de dependencias extraído de tasks.md}
+Las tareas sin dependencias pueden delegarse en paralelo.
+````
+
+### Paso GE4 — Mostrar y ofrecer guardar
+
+Mostrar el prompt completo en pantalla.
+
+AskUserQuestion:
+
+```json
+{
+  "questions": [{
+    "header": "Prompt de ejecución",
+    "question": "🚀 Prompt generado. ¿Qué quieres hacer?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "💾 Guardar como sdd-execution-prompt.md",
+        "description": "Guardar en el mismo directorio que el SDD"
+      },
+      {
+        "label": "✅ Listo — ya lo he copiado",
+        "description": "Volver al Consejo de Rivendel"
+      }
+    ]
+  }]
+}
+```
+
+Si elige guardar: escribir el fichero `sdd-execution-prompt.md` en el directorio del SDD con Write.
+Mostrar confirmación y volver al Consejo de Rivendel.
 
 ---
 


### PR DESCRIPTION
## Summary

- **T01**: Reemplaza ASCII art de Gandalf por silueta de mago con sombrero + bastón (solo ASCII 32-126)
- **T02**: Añade bloque `verificar-lead` en `gandalf-main.md` tras selección de team (indicadores: `orchestrat|coordin|team lead|delegate`)
- **T03**: Replica `verificar-lead` en `aragorn-main.md` con lore de Gondor/ejércitos (`# SYNC: verificar-lead`)
- **T04**: Elimina pregunta de scope en `02-module-create.md`, hardcodea `~/.claude/agents/` siempre global
- **T05**: Añade opción "🛡️ Forjar un Coordinador de Ejércitos" en `03-module-team-builder.md` con flujo completo (F1-F5)
- **T06**: Añade opción "🚀 Crear tarea de ejecución del SDD" en `08-module-council.md`
- **T07**: Genera prompt de orquestación completo cuando `GANDALF_TEAM` está definido (tabla agente→tarea + regla "ORQUESTAR, no implementar")

## Test plan

- [ ] Verificar que el nuevo ASCII art de Gandalf se renderiza correctamente en terminal
- [ ] Comprobar que el flujo verificar-lead se activa al seleccionar un team en Gandalf
- [ ] Comprobar que el flujo verificar-lead se activa en Aragorn con lore correcto
- [ ] Confirmar que la creación de agentes en Aragorn ya no pregunta el scope
- [ ] Verificar que "Forjar Coordinador" genera el agente en `~/.claude/agents/` y ofrece actualizar config.json del team
- [ ] Verificar que el Consejo de Rivendel muestra la opción de ejecución del SDD
- [ ] Comprobar que el prompt de orquestación incluye tabla agente→tarea cuando hay GANDALF_TEAM

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)