### PR TITLE
feat(aragorn): lead obligatorio al crear team + distinción Lead/Worker en agentes

### DIFF
--- a/prompts/aragorn/ar1-listar-agentes.md
+++ b/prompts/aragorn/ar1-listar-agentes.md
@@ -48,6 +48,7 @@ Del frontmatter YAML (delimitado por `---`) extraer:
 - `description` — para qué sirve
 - `tools` — lista de herramientas permitidas
 - `model` — modelo asignado (opcional)
+- `type` — tipo de agente: lead o worker (opcional, si no existe: worker por defecto)
 - `permissionMode` — nivel de permisos (opcional)
 
 ---
@@ -62,24 +63,24 @@ Formatea el output así:
 
 🌍 Scope: global  (~/.claude/agents/) — 3 agentes
 ────────────────────────────────────────────────
-  1. code-reviewer
+  1. code-reviewer                               [👑 Lead]
      📝 Revisa código buscando bugs, security issues y mejoras de calidad
      🔧 Tools: Read, Grep, Glob
      🤖 Model: (por defecto)
 
-  2. test-writer
+  2. test-writer                                 [⚙️ Worker]
      📝 Genera tests unitarios y E2E para el código indicado
      🔧 Tools: Read, Write, Bash
      🤖 Model: claude-sonnet-4-6
 
-  3. symfony-expert
+  3. symfony-expert                              [⚙️ Worker]
      📝 Experto en Symfony/PHP para análisis de bundles y services
      🔧 Tools: Read, Write, Bash, Grep
      🔐 Mode: acceptEdits
 
 📁 Scope: proyecto  (.claude/agents/) — 1 agente
 ────────────────────────────────────────────────
-  1. deploy-guardian
+  1. deploy-guardian                             [⚙️ Worker]
      📝 Supervisa deploys y verifica que los checks pasen antes de mergear
      🔧 Tools: Bash, Read
 

--- a/prompts/aragorn/sections/00-module-analyze.md
+++ b/prompts/aragorn/sections/00-module-analyze.md
@@ -71,6 +71,7 @@ Para cada fichero `.md` detectado, leerlo con la herramienta Read y extraer:
 - `model` del frontmatter
 - `permissionMode` del frontmatter
 - `maxTurns` del frontmatter
+- `type` del frontmatter (lead/worker — si no existe, tratar como worker)
 - Cualquier otro campo relevante
 
 Si un agente no tiene frontmatter delimitado por `---`, marcarlo como sin estructura válida.
@@ -127,9 +128,9 @@ Score global = media de puntuaciones individuales (redondeado a 1 decimal)
 ⚔️  AGENTES INSTALADOS
 ──────────────────────────────────────────────────────────────
   🌍 Global (~/.claude/agents/):
-    👑 10/10  code-reviewer     — name ✅ · description clara ✅ · tools ✅
-    ⚔️  7/10  symfony-expert    — name ✅ · description corta ⚠️ · tools ✅
-    💀  3/10  old-agent         — sin frontmatter ❌ · sin description ❌
+    👑 10/10  code-reviewer [👑 Lead]   — name ✅ · description clara ✅ · tools ✅
+    ⚔️  7/10  symfony-expert [⚙️ Worker] — name ✅ · description corta ⚠️ · tools ✅
+    💀  3/10  old-agent [⚙️ Worker]     — sin frontmatter ❌ · sin description ❌
 
   📁 Proyecto (.claude/agents/):
     ⚔️  8/10  deploy-guardian   — name ✅ · sin tools ⚠️ · sin model ℹ️

--- a/prompts/aragorn/sections/02-module-create.md
+++ b/prompts/aragorn/sections/02-module-create.md
@@ -42,7 +42,7 @@ Preguntar con AskUserQuestion:
 ```json
 {
   "questions": [{
-    "header": "Crear agente — Paso 1/5",
+    "header": "Crear agente — Paso 1/6",
     "question": "✨ ¿Cómo se llamará el nuevo agente?\n(ej: symfony-expert, playwright-agent, code-reviewer-php)",
     "multiSelect": false,
     "options": [
@@ -86,7 +86,39 @@ de Agent Teams — quedarían encerrados en un único repositorio.
 
 ---
 
-## Paso 2 — Descripción (campo más crítico)
+## Paso 2 — Tipo de agente
+
+Preguntar con AskUserQuestion:
+
+```json
+{
+  "questions": [{
+    "header": "Crear agente — Paso 2/6",
+    "question": "⚔️ ¿Qué tipo de agente es?\n\n• Lead: coordina y delega trabajo a otros agentes. No implementa directamente.\n• Worker: implementa y ejecuta las tareas él mismo.",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "👑 Lead — Coordinador y delegador",
+        "description": "Orquesta a otros agentes, no implementa directamente"
+      },
+      {
+        "label": "⚙️ Worker — Implementador",
+        "description": "Ejecuta tareas concretas: código, tests, análisis..."
+      },
+      {
+        "label": "🔙 Volver al menú de Aragorn",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+Guardar la elección como `type: lead` o `type: worker` para incluirla en el frontmatter.
+
+---
+
+## Paso 3 — Descripción (campo más crítico)
 
 **CRÍTICO**: La `description` es el campo más importante de un agente. Claude la lee
 para decidir cuándo invocarlo automáticamente. Debe incluir:
@@ -97,7 +129,7 @@ para decidir cuándo invocarlo automáticamente. Debe incluir:
 Mostrar antes de preguntar:
 
 ```
-✨ CREAR AGENTE — Paso 2/5: Descripción
+✨ CREAR AGENTE — Paso 3/6: Descripción
 ══════════════════════════════════════════════════════════════
 
 ⚠️  La descripción es el campo MÁS CRÍTICO del agente.
@@ -127,12 +159,12 @@ Si elige ver sugerencia, proponer una versión expandida basada en el nombre y s
 
 ---
 
-## Paso 3 — Tools permitidas
+## Paso 4 — Tools permitidas
 
 Mostrar lista de tools disponibles según docs oficiales:
 
 ```
-✨ CREAR AGENTE — Paso 3/5: Herramientas
+✨ CREAR AGENTE — Paso 4/6: Herramientas
 ══════════════════════════════════════════════════════════════
 
 Tools disponibles para el agente:
@@ -147,7 +179,7 @@ Preguntar con AskUserQuestion:
 ```json
 {
   "questions": [{
-    "header": "Crear agente — Paso 3/5",
+    "header": "Crear agente — Paso 4/6",
     "question": "🔧 ¿Qué herramientas necesita el agente?",
     "multiSelect": false,
     "options": [
@@ -174,14 +206,14 @@ Preguntar con AskUserQuestion:
 
 ---
 
-## Paso 4 — Modelo y permisos
+## Paso 5 — Modelo y permisos
 
 Preguntar con AskUserQuestion:
 
 ```json
 {
   "questions": [{
-    "header": "Crear agente — Paso 4/5",
+    "header": "Crear agente — Paso 5/6",
     "question": "🤖 ¿Qué modelo y modo de permisos?",
     "multiSelect": false,
     "options": [
@@ -238,14 +270,14 @@ También preguntar `maxTurns` opcionalmen:
 
 ---
 
-## Paso 5 — Instrucciones del agente (cuerpo del fichero)
+## Paso 6 — Instrucciones del agente (cuerpo del fichero)
 
 Tras el frontmatter, el fichero `.md` puede tener instrucciones adicionales en Markdown.
 
 Mostrar:
 
 ```
-✨ CREAR AGENTE — Paso 5/5: Instrucciones
+✨ CREAR AGENTE — Paso 6/6: Instrucciones
 ══════════════════════════════════════════════════════════════
 
 El cuerpo del fichero (tras el frontmatter) define el comportamiento
@@ -303,6 +335,7 @@ Destino: ~/.claude/agents/symfony-expert.md
 --- Contenido ---
 ---
 name: symfony-expert
+type: worker
 description: |
   Experto en Symfony y PHP para este proyecto.
   Invócame para: analizar services y repositorios,
@@ -363,6 +396,9 @@ mkdir -p ~/.claude/agents/
 ```
 
 Escribir el fichero `.md` usando Write.
+
+El frontmatter generado debe incluir el campo `type` (lead o worker) justo después de `name`,
+con el valor seleccionado por el usuario en el Paso 2.
 
 ---
 

--- a/prompts/aragorn/sections/03-module-team-builder.md
+++ b/prompts/aragorn/sections/03-module-team-builder.md
@@ -23,6 +23,7 @@ ls .claude/agents/ 2>/dev/null || echo "(vacío)"
 
 Para cada fichero/directorio encontrado, leer su contenido con Read para extraer:
 - Nombre del team
+- Campo `lead` del fichero de configuración del team
 - Número de agentes miembros (campos `teammates` o equivalente según docs)
 
 ### Paso F0.2 — Mostrar inventario
@@ -37,12 +38,12 @@ Para cada fichero/directorio encontrado, leer su contenido con Read para extraer
   🌍 GLOBAL (~/.claude/agents/):
   [Para cada team global]:
     ⚔️  [nombre-team]
-       🧑‍🤝‍🧑 Agentes: [N]  ·  🗡️ [lista nombres separados por coma]
+       👑 Lead: [nombre-lead]  ·  🧑‍🤝‍🧑 Workers: [N]  ·  🗡️ [lista nombres separados por coma]
 
   📁 PROYECTO (.claude/agents/):
   [Para cada team de proyecto]:
     ⚔️  [nombre-team]
-       🧑‍🤝‍🧑 Agentes: [N]  ·  🗡️ [lista nombres separados por coma]
+       👑 Lead: [nombre-lead]  ·  🧑‍🤝‍🧑 Workers: [N]  ·  🗡️ [lista nombres separados por coma]
 
   [Si algún scope está vacío, omitir esa sección]
 
@@ -327,7 +328,7 @@ Preguntar con AskUserQuestion:
 ```json
 {
   "questions": [{
-    "header": "Nuevo team — Paso 1/4",
+    "header": "Nuevo team — Paso 1/5",
     "question": "⚔️  ¿Cómo se llamará el team?\n(ej: full-stack-review, security-audit, deploy-guard)",
     "multiSelect": false,
     "options": [
@@ -357,7 +358,7 @@ ls .claude/teams/[nombre].yml 2>/dev/null
 Mostrar todos los agentes disponibles y pedir selección con multiSelect:
 
 ```
-⚔️  NUEVO TEAM — Paso 2/4
+⚔️  NUEVO TEAM — Paso 2/5
 ══════════════════════════════════════════════════════════════
 
 Agentes disponibles:
@@ -390,6 +391,60 @@ Selecciona los agentes para "[nombre-del-team]"
 
 Nota: generar opciones dinámicamente según los agentes reales detectados en el Paso A1.
 
+### Paso A4b — Asignar lead del team (obligatorio)
+
+**OBLIGATORIO**: Todo team debe tener exactamente un lead asignado. No se puede avanzar sin lead.
+
+Mostrar:
+
+```
+⚔️  NUEVO TEAM — Paso 3/5
+══════════════════════════════════════════════════════════════
+
+Un team necesita un Capitán que coordine la batalla.
+Agentes seleccionados para "[nombre-del-team]":
+  [lista de agentes seleccionados en el paso anterior, indicando si son Lead o Worker]
+
+══════════════════════════════════════════════════════════════
+```
+
+**Detectar candidatos a lead**: entre los agentes seleccionados, identificar los que tengan `type: lead` en su frontmatter. Si hay alguno, mostrarlos primero como candidatos sugeridos.
+
+Preguntar con AskUserQuestion:
+
+```json
+{
+  "questions": [{
+    "header": "Asignar lead — Paso 3/5",
+    "question": "👑 ¿Quién liderará este ejército?\n(El lead coordina y delega. Debe ser un agente de tipo Lead.)",
+    "multiSelect": false,
+    "options": [
+      { "label": "👑 [agente-lead-1] — [descripción breve]", "description": "Tipo: Lead" },
+      { "label": "⚙️ [agente-worker-1] — [descripción breve]", "description": "⚠️ Es Worker — considera crear un Lead primero" },
+      {
+        "label": "✨ Crear un nuevo agente Lead ahora",
+        "description": "Ir al módulo de creación de agentes y volver"
+      }
+    ]
+  }]
+}
+```
+
+**Nota**: Generar las opciones dinámicamente con los agentes seleccionados en el Paso A4.
+Los agentes con `type: lead` se muestran sin advertencia. Los `type: worker` o sin tipo se marcan con `⚠️ Es Worker`.
+
+Si el usuario elige un agente Worker como lead: mostrar aviso informativo pero permitir continuar:
+```
+⚠️  Este agente es de tipo Worker, no Lead.
+    Funcionará como coordinador, pero considera convertirlo a Lead
+    en "Inspeccionar arsenal" para mantener consistencia.
+```
+
+Si el usuario elige "Crear un nuevo agente Lead": ir al módulo de creación (`02-module-create.md`)
+con el tipo pre-seleccionado como Lead, y al terminar volver a este paso con el nuevo agente como lead seleccionado.
+
+Guardar el lead elegido para incluirlo en la configuración del team.
+
 ### Paso A5 — Descripción del team
 
 Preguntar al usuario para qué se usará el team (AskUserQuestion con campo libre).
@@ -415,6 +470,9 @@ mkdir -p .claude/teams/
 Escribir el fichero `.claude/teams/[nombre].yml` usando Write con la estructura
 extraída de las docs oficiales.
 
+El fichero de configuración debe incluir el campo `lead` con el nombre del agente seleccionado
+como lead en el Paso A4b, según la estructura extraída de las docs oficiales.
+
 ### Paso A7 — Confirmación con lore épico
 
 Asignar un nombre de batalla al team basado en los agentes y su propósito:
@@ -426,6 +484,7 @@ Asignar un nombre de batalla al team basado en los agentes y su propósito:
 
   🏰 "[Frase épica de batalla — variada]"
 
+  Capitán:  👑 [nombre-del-lead]
   Guerreros convocados:
     [emoji-personaje] [Personaje] ([nombre-agente]) — "[frase breve]"
     [emoji-personaje] [Personaje] ([nombre-agente]) — "[frase breve]"


### PR DESCRIPTION
## Summary

- Nuevo paso "Tipo de agente" (Lead/Worker) en el flujo de creación de agentes (`02-module-create.md`), pasando de 5 a 6 pasos
- Indicador `[Lead]`/`[Worker]` en el listado de agentes (`ar1-listar-agentes.md`) y en el informe de inspección con scoring (`00-module-analyze.md`)
- Lead obligatorio al crear un team (`03-module-team-builder.md`): nuevo Paso A4b con AskUserQuestion dinámico, detección de candidatos Lead, aviso si se elige Worker, opción de crear Lead on-the-fly
- Campo `lead` incluido en la configuración generada del team y en la confirmación épica

## Test plan

- [ ] Verificar que el flujo de creación de agentes muestra el nuevo Paso 2/6 (Tipo de agente) y los contadores van de 1/6 a 6/6
- [ ] Verificar que el listado de agentes muestra `[Lead]` o `[Worker]` junto a cada agente
- [ ] Verificar que el informe de inspección muestra el tipo en la línea de scoring
- [ ] Verificar que al crear un team aparece el Paso A4b de asignación de lead
- [ ] Verificar que el inventario de teams muestra el campo Lead
- [ ] Verificar que la confirmación épica incluye la línea "Capitán"

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)