### PR TITLE
feat(gandalf): mejoras de lore, banner, mini-guía y agentes dinámicos (#321)

### DIFF
--- a/prompts/gandalf/gandalf-main.md
+++ b/prompts/gandalf/gandalf-main.md
@@ -14,45 +14,53 @@
 **SIEMPRE** mostrar este banner al iniciar Gandalf:
 
 ```
-══════════════════════════════════════════════════════════════
-  ᚷᚨᚾᛞᚨᛚᚠ  ⚡  GANDALF — El Mago Blanco  ᚷᚨᚾᛞᚨᛚᚠ
-══════════════════════════════════════════════════════════════
-    Spec-Driven Development · TLOTP {VERSION}
-──────────────────────────────────────────────────────────────
+╔══════════════════════════════════════════════════════════════╗
+║                                                              ║
+║      ᚷᚨᚾᛞᚨᛚᚠ  ⚡  G A N D A L F  ⚡  ᚷᚨᚾᛞᚨᛚᚠ              ║
+║                                                              ║
+║         El Mago Blanco · Spec-Driven Development             ║
+║                      TLOTP {VERSION}                         ║
+║                                                              ║
+║   "Un mago nunca llega tarde, Frodo Bolsón. Ni tampoco       ║
+║    pronto. Llega exactamente cuando se lo propone."          ║
+║                           — Gandalf el Gris                  ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+```
 
-  "Un mago nunca llega tarde, ni pronto.
-   Llega exactamente cuando lo decide... y con el mapa ya hecho."
+**IMPORTANTE**: Reemplaza `{VERSION}` con la version actual cargada desde `@prompts/VERSION.md`
 
-              _....._
-           .-'       '-.
-          /   .-"""-.   \
-         /  .'       '.  \
-        |  /   (**)   \  |
-         \  '.       .'  /
-          '-.`-------'.-'
-         ____|       |____
-        /    |       |    \
-       /     |       |     \
-      /      |  SDD  |      \
-     '-------| ANTES |-------'
-             | CODER |
-              \     /
-               \   /
-                | |
-               _| |_
-              / | | \
-             '  | |  '
+---
 
-  Antes de que La Comunidad dé un solo paso hacia Mordor,
-  Gandalf envía sus jinetes más veloces a explorar el terreno.
+## Mini-guia de Gandalf
 
-  Los Exploradores Rohirrim cabalgan sin que el usuario espere.
-  Cuando regresan, el mapa está listo. La aventura puede comenzar.
+**Mostrar inmediatamente despues del banner, sin interaccion:**
 
-  Sin especificación no hay expedición. Sin mapa no hay victoria.
-  El vibe coding es el Camino de los Muertos — nadie regresa.
+```
+⚡ El Mago Blanco — Gandalf
 
-══════════════════════════════════════════════════════════════
+"Antes de que La Comunidad dé un solo paso hacia Mordor,
+ Gandalf envía sus jinetes más veloces a explorar el terreno.
+ Sin especificación no hay expedición. Sin mapa no hay victoria.
+ El vibe coding es el Camino de los Muertos — nadie regresa."
+
+Los Exploradores Rohirrim cabalgan sin que el usuario espere.
+Cuando regresan, el mapa está listo. La aventura puede comenzar.
+
+✨ Nueva aventura SDD
+   Los Rohirrim exploran → tú defines el objetivo → Gandalf
+   genera requirements.md · design.md · tasks.md
+
+🔄 Continuar aventura en curso
+   Detectar SDD existente y retomar donde se dejó
+
+🏇 Solo exploración Rohirrim
+   Lanzar los exploradores y ver el mapa sin crear SDD
+
+📜 Los Pergaminos del Mago
+   Documentación oficial: Plan Mode, Kiro, EARS
+
+══════════════════════════════════════════════════════
 ```
 
 ---

--- a/prompts/gandalf/sections/01-module-rohirrim.md
+++ b/prompts/gandalf/sections/01-module-rohirrim.md
@@ -23,8 +23,8 @@ Mostrar animación adaptada:
   Los jinetes del team cabalgan hacia el horizonte.
   Sus especialidades guían la exploración.
 
-  🏇 [nombre-agente-1] ([tipo]) ....  ⚔️  en misión
-  🏇 [nombre-agente-2] ([tipo]) ....  ⚔️  en misión
+  🏇 [nombre-agente] ([nombre de lore]) — [especialidad] ....  ⚔️  en misión
+  🏇 [nombre-agente] ([nombre de lore]) — [especialidad] ....  ⚔️  en misión
   ...
 
 ══════════════════════════════════════════════════════════════
@@ -40,6 +40,32 @@ Los roles de exploración se adaptan según el tipo de agente:
 - `typescript-pro` → explora stack TypeScript
 - `database-administrator` → explora bases de datos y schemas
 - Cualquier otro → exploración genérica del proyecto
+
+### Nombres de lore por especialidad
+
+Al mostrar al usuario los agentes del team y asignar roles de exploración,
+mapear cada agente con un nombre de lore según su especialidad detectada
+(por nombre o descripción del agente):
+
+| Especialidad detectada (en nombre/descripción) | Nombre de lore asignado |
+|------------------------------------------------|------------------------|
+| git, branch, ramas, versionado | **Thorin Escudo de Roble** |
+| CI/CD, pipeline, infraestructura, docker | **Bárbol** |
+| PHP, backend, symfony, laravel | **Frodo Bolsón** / **Sam Gamyi** / **Merry** / **Pippin** (hobbits, rotar si hay varios) |
+| scrum, agile, facilitación | **Gandalf** |
+| product owner, producto, estrategia, roadmap | **Aragorn** |
+| frontend, UI, react, vue, CSS | **Boromir** / **Faramir** / **Éomer** (rotar si hay varios) |
+| IA, LLM, machine learning, embeddings | **Legolas** / **Elrond** / **Galadriel** (rotar si hay varios) |
+| Sin match claro | usar nombre real del agente sin nombre de lore |
+
+Al mostrar la animación de despliegue con Agent Team, incluir tanto el nombre
+real del agente como su nombre de lore entre paréntesis. Ejemplo:
+
+```
+🏇 typescript-pro (Boromir de Gondor) — Frontend
+🏇 php-pro (Frodo Bolsón) — Backend PHP
+🏇 devops-engineer (Bárbol) — CI/CD
+```
 
 Lanzar un Agent por cada explorador de `GANDALF_EXPLORERS` en paralelo, adaptando
 el prompt de exploración según el tipo de agente listado arriba.

--- a/prompts/gandalf/sections/02-module-field-report.md
+++ b/prompts/gandalf/sections/02-module-field-report.md
@@ -53,6 +53,13 @@ El mapa del terreno, firmado por los cinco jinetes.
 **IMPORTANTE**: El informe usa los datos reales devueltos por los agentes.
 No inventar ni rellenar con ejemplos si el agente devolvió "sin datos".
 
+**Nombres dinámicos**: Si `GANDALF_TEAM` está activo y hay exploradores asignados,
+sustituir los nombres clásicos (Éowyn, Théoden, Merry, Pippin, Gamling) por los
+nombres reales de los agentes del team junto con su nombre de lore asignado
+(ver tabla de mapping en `01-module-rohirrim.md`). Ejemplo:
+`🏇 PHP-PRO (FRODO BOLSÓN)` en lugar de `🏇 THÉODEN DEL DOMINIO`.
+Si no hay team activo, mantener los nombres clásicos de los Rohirrim.
+
 ---
 
 ## Paso de Consenso del Consejo (condicional)
@@ -151,8 +158,8 @@ Si el usuario elige corregir, preguntar qué sección:
         "description": ""
       },
       {
-        "label": "🏇 Théoden del Dominio — arquitectura y módulos",
-        "description": ""
+        "label": "🏇 [agente de dominio] — arquitectura y módulos",
+        "description": "Si GANDALF_TEAM activo: usar el nombre del agente asignado al análisis de dominio/arquitectura (con su nombre de lore). Si no hay team: 'Théoden del Dominio'."
       },
       {
         "label": "🏇 Merry de la Forja — testing y calidad",

--- a/prompts/gandalf/sections/06-module-design.md
+++ b/prompts/gandalf/sections/06-module-design.md
@@ -3,14 +3,17 @@
 ## Misión
 
 Crear `design.md` con la arquitectura de la aventura, diagramas Mermaid y decisiones
-técnicas documentadas. Usa el informe de Théoden del Dominio como base.
+técnicas documentadas. Usa el informe del explorador de dominio/arquitectura como base
+(Théoden del Dominio en modo clásico, o el agente asignado del team si `GANDALF_TEAM` activo).
 Sin planos, los cimientos se hunden.
 
 ---
 
 ## Paso 0 — Pre-carga de contexto
 
-Leer del `contexto_rohirrim` (Théoden del Dominio) la arquitectura detectada.
+Leer del `contexto_rohirrim` la arquitectura detectada (explorador de dominio:
+Théoden del Dominio en modo clásico, o el agente asignado del team con su nombre de lore
+si `GANDALF_TEAM` activo — ver tabla de mapping en `01-module-rohirrim.md`).
 Si existe `requirements.md`, leerlo para alinear el diseño con los requisitos.
 
 Si `contexto_docs` está disponible: usar la documentación oficial del stack
@@ -23,13 +26,17 @@ para alinear el diseño con los patrones y convenciones oficiales de cada tecnol
 Preguntar si el usuario quiere confirmar o ajustar la arquitectura detectada:
 
 ```
-⚡ "Théoden del Dominio reportó la siguiente arquitectura:"
+⚡ "[explorador de dominio] reportó la siguiente arquitectura:"
 
-  🏰 Tipo de app:    [app_type de Théoden]
-  🏛️  Patrón:        [architecture_pattern de Théoden]
+  🏰 Tipo de app:    [app_type del explorador de dominio]
+  🏛️  Patrón:        [architecture_pattern del explorador de dominio]
   📦 Módulos:       [lista de módulos]
   🖥️  Frontend:      [sí/no — tipo]
 ```
+
+**Nombre del explorador de dominio**: Si `GANDALF_TEAM` activo, usar el nombre real
+del agente asignado + su nombre de lore (ej: `php-pro (Frodo Bolsón)`).
+Si no hay team, usar `Théoden del Dominio`.
 
 AskUserQuestion:
 ```json
@@ -40,7 +47,7 @@ AskUserQuestion:
     "multiSelect": false,
     "options": [
       {
-        "label": "✅ Confirmar — Théoden la mapeó bien",
+        "label": "✅ Confirmar — [explorador de dominio] la mapeó bien",
         "description": ""
       },
       {
@@ -118,7 +125,7 @@ Listar los componentes principales del diseño con:
 - Dependencias
 - Interfaz pública (endpoints, métodos clave o eventos)
 
-Inferir de los módulos de Théoden + los requisitos de G5.
+Inferir de los módulos del explorador de dominio (Théoden o agente del team) + los requisitos de G5.
 Revisar uno a uno con el patrón estándar (✅/✏️/⏭️/🚫).
 
 ---

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -198,7 +198,7 @@ Patrón fijo: 3 opciones de contenido por página. Pantalla 1: 3 épicas + "➕ 
         "description": ""
       },
       {
-        "label": "⚡ Consultar al Mago Blanco — Gandalf",
+        "label": "⚡ Iniciar una nueva aventura, Gandalf nos espera",
         "description": ""
       },
       {
@@ -216,7 +216,7 @@ Patrón fijo: 3 opciones de contenido por página. Pantalla 1: 3 épicas + "➕ 
 - ⚒️ Peregrinaje a Eregion, Celebrimbor nos espera → Cargar `@prompts/celebrimbor/celebrimbor-main.md`
 - 🏹 Reunir monedas para Bardo → Cargar `@prompts/bardo/bardo-main.md`
 - 👑 Entregar Andúril a Aragorn — El Heredero de Isildur nos espera → Cargar `@prompts/aragorn/aragorn-main.md`
-- ⚡ Consultar al Mago Blanco — Gandalf → Cargar `@prompts/gandalf/gandalf-main.md`
+- ⚡ Iniciar una nueva aventura, Gandalf nos espera → Cargar `@prompts/gandalf/gandalf-main.md`
 - 🔙 Volver a página 1 → Mostrar Pantalla 1
 - 🚪 Salir → Mensaje de despedida épico y terminar
 
@@ -226,9 +226,9 @@ Patrón fijo: 3 opciones de contenido por página. Pantalla 1: 3 épicas + "➕ 
 
 ---
 
-## ⚡ Contenido de "Consultar al Mago Blanco — Gandalf"
+## ⚡ Contenido de "Iniciar una nueva aventura, Gandalf nos espera"
 
-**Si el usuario selecciona "⚡ Consultar al Mago Blanco — Gandalf"**:
+**Si el usuario selecciona "⚡ Iniciar una nueva aventura, Gandalf nos espera"**:
 
 → Cargar `@prompts/gandalf/gandalf-main.md`
 


### PR DESCRIPTION
## ⚡ El Mago Blanco se renueva

Mejoras de lore y UX de la épica Gandalf. Cierra #321.

## 📦 Cambios

| Archivo | Cambio |
|---------|--------|
| `prompts/tlotp-main.md` | Descripción de Gandalf en menú → *"Iniciar una nueva aventura, Gandalf nos espera."* |
| `prompts/gandalf/gandalf-main.md` | Banner rediseñado al estilo Ents/Palantír (sin icono ASCII) + frase exacta de película + mini-guía de funcionalidades |
| `prompts/gandalf/sections/01-module-rohirrim.md` | Mapping especialidad → nombre de lore (Thorin, Bárbol, hobbits, Boromir, Legolas...) |
| `prompts/gandalf/sections/02-module-field-report.md` | Théoden del Dominio → agente dinámico del team cuando hay team activo |
| `prompts/gandalf/sections/06-module-design.md` | Ídem — 6 referencias actualizadas |

## ✨ Highlights

- **Frase de película exacta**: *"Un mago nunca llega tarde, Frodo Bolsón. Ni tampoco pronto. Llega exactamente cuando se lo propone."*
- **Mini-guía** al estilo Ents/Palantír con las 4 funcionalidades principales
- **Agentes con lore**: al usar un Agent Team, cada agente recibe su nombre épico según especialidad
- **Théoden dinámico**: el análisis de dominio lo firma el agente real del team, no un nombre estático

🤖 Generated with [Claude Code](https://claude.com/claude-code)