### PR TITLE
feat(pipeline+web+gandalf): semver desde VERSION.md, @imports como links y mini-guía actualizada (#331)

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -28,57 +28,32 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Obtener último tag
-        id: last_tag
+      - name: Leer versión desde VERSION.md
+        id: version
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "tag=$LAST_TAG" >> $GITHUB_OUTPUT
-          echo "Último tag: $LAST_TAG"
+          VERSION=$(grep -oP '(?<=\*\*TLOTP v)[0-9]+\.[0-9]+\.[0-9]+(?=\*\*)' prompts/VERSION.md | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::No se encontró la versión en prompts/VERSION.md (formato esperado: **TLOTP vX.Y.Z**)"
+            exit 1
+          fi
+          NEW_VERSION="v${VERSION}"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Versión leída de VERSION.md: $NEW_VERSION"
 
-      - name: Analizar commits y determinar bump
-        id: bump
+      - name: Verificar si el tag ya existe
+        id: check_tag
         run: |
-          LAST_TAG="${{ steps.last_tag.outputs.tag }}"
-          COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
-
-          echo "Commits desde $LAST_TAG:"
-          echo "$COMMITS"
-
-          BUMP="none"
-
-          if echo "$COMMITS" | grep -qE "^feat!:|BREAKING CHANGE"; then
-            BUMP="major"
-          elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
-            BUMP="minor"
-          elif echo "$COMMITS" | grep -qE "^fix(\(.+\))?:"; then
-            BUMP="patch"
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          if git tag -l "$NEW_VERSION" | grep -q "$NEW_VERSION"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "ℹ️  El tag $NEW_VERSION ya existe — no se creará de nuevo"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "✅ El tag $NEW_VERSION no existe — se procederá a crearlo"
           fi
 
-          echo "bump=$BUMP" >> $GITHUB_OUTPUT
-          echo "Tipo de bump: $BUMP"
-
-      - name: Calcular nueva versión
-        id: version
-        if: steps.bump.outputs.bump != 'none'
-        run: |
-          LAST_TAG="${{ steps.last_tag.outputs.tag }}"
-          VERSION="${LAST_TAG#v}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
-
-          case "${{ steps.bump.outputs.bump }}" in
-            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH + 1)) ;;
-          esac
-
-          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Nueva versión: $NEW_VERSION"
-
       - name: Crear tag
-        if: steps.bump.outputs.bump != 'none'
+        if: steps.check_tag.outputs.exists == 'false'
         id: tag
         run: |
           NEW_VERSION="${{ steps.version.outputs.version }}"
@@ -89,7 +64,7 @@ jobs:
           echo "✅ Tag ${NEW_VERSION} publicado"
 
       - name: Preparar changelog
-        if: steps.bump.outputs.bump != 'none'
+        if: steps.check_tag.outputs.exists == 'false'
         id: changelog
         run: |
           NEW_VERSION="${{ steps.version.outputs.version }}"
@@ -99,7 +74,7 @@ jobs:
           # Si no hay sección específica, generar un resumen de commits
           if [ ! -s /tmp/changelog.md ]; then
             echo "::warning::No se encontró la sección ### ${NEW_VERSION} en prompts/VERSION.md — usando fallback de commits"
-            LAST_TAG="${{ steps.last_tag.outputs.tag }}"
+            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "v0.0.0")
             echo "## Cambios desde ${LAST_TAG}" > /tmp/changelog.md
             echo "" >> /tmp/changelog.md
             git log "${LAST_TAG}..HEAD" --pretty=format:"- %s" >> /tmp/changelog.md
@@ -107,7 +82,7 @@ jobs:
           cat /tmp/changelog.md
 
       - name: Crear GitHub Release
-        if: steps.bump.outputs.bump != 'none'
+        if: steps.check_tag.outputs.exists == 'false'
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
@@ -116,8 +91,8 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Sin cambios que versionar
-        if: steps.bump.outputs.bump == 'none'
+      - name: Tag ya existente — sin acción
+        if: steps.check_tag.outputs.exists == 'true'
         run: |
-          echo "ℹ️  No se detectaron commits feat/fix desde ${{ steps.last_tag.outputs.tag }}"
-          echo "   Solo docs, chore, refactor u otros — no se bumpa la versión"
+          echo "ℹ️  El tag ${{ steps.version.outputs.version }} ya existe en el repositorio"
+          echo "   Si necesitas re-crear la release, borra el tag primero"

--- a/prompts/gandalf/gandalf-main.md
+++ b/prompts/gandalf/gandalf-main.md
@@ -37,30 +37,33 @@
 **Mostrar inmediatamente despues del banner, sin interaccion:**
 
 ```
-⚡ El Mago Blanco — Gandalf
+⚡ GANDALF — Guía Rápida
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-"Antes de que La Comunidad dé un solo paso hacia Mordor,
- Gandalf envía sus jinetes más veloces a explorar el terreno.
- Sin especificación no hay expedición. Sin mapa no hay victoria.
- El vibe coding es el Camino de los Muertos — nadie regresa."
+  ✨ Nueva aventura SDD
+     Gandalf detecta si tienes Agent Teams disponibles.
+     Si los tienes, puedes activar uno — sus agentes reciben
+     nombres de lore según su especialidad:
+       🪨 Git/Ramas → Thorin Escudo de Roble
+       🌳 CI/CD     → Bárbol
+       🧙 PHP/Back  → Frodo, Sam, Merry, Pippin
+       ⚔️ Frontend  → Boromir, Faramir, Éomer
+       🧝 IA/LLM    → Legolas, Elrond, Galadriel
+     Con team: los Rohirrim son tus agentes. El análisis de
+     dominio lo firma el agente asignado (no "Théoden").
+     Sin team: 5 Rohirrim clásicos exploran en paralelo.
+     Resultado: requirements.md · design.md · tasks.md
 
-Los Exploradores Rohirrim cabalgan sin que el usuario espere.
-Cuando regresan, el mapa está listo. La aventura puede comenzar.
+  🔄 Continuar aventura
+     Detecta SDD existente y retoma donde lo dejaste.
 
-✨ Nueva aventura SDD
-   Los Rohirrim exploran → tú defines el objetivo → Gandalf
-   genera requirements.md · design.md · tasks.md
+  🏇 Solo exploración Rohirrim
+     Mapea el proyecto sin crear ficheros SDD.
 
-🔄 Continuar aventura en curso
-   Detectar SDD existente y retomar donde se dejó
+  📜 Los Pergaminos del Mago
+     Documentación oficial: Plan Mode · Kiro · EARS
 
-🏇 Solo exploración Rohirrim
-   Lanzar los exploradores y ver el mapa sin crear SDD
-
-📜 Los Pergaminos del Mago
-   Documentación oficial: Plan Mode, Kiro, EARS
-
-══════════════════════════════════════════════════════
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ---

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -96,6 +96,9 @@ generate_html() {
   local content
   content="$(escape_html < "$md_file")"
 
+  # Transformar @prompts/ruta/archivo.md → enlace clickable a josemoreupeso.es/tlotp/
+  content=$(echo "$content" | sed 's|@prompts/\([^&"<>[:space:]]*\)\.md|<a href="https://josemoreupeso.es/tlotp/\1.html" style="color:var(--accent-primary)">@prompts/\1.md</a>|g')
+
   if [ "$is_main" = true ] && [ -n "$epic" ]; then
     local emoji
     emoji="$(emoji_for_epic "$epic")"
@@ -134,7 +137,7 @@ pre{font-family:var(--font-mono);white-space:pre-wrap;word-wrap:break-word;font-
 </head>
 <body>
 <header style="background:var(--bg-secondary);border-bottom:1px solid var(--border-color);padding:0.75rem 2rem;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100;">
-  <a href="/tlotp/" style="color:var(--accent-primary);font-family:var(--font-sans);font-weight:600;font-size:0.95rem;text-decoration:none;">&larr; TLOTP</a>
+  <a href="https://josemoreupeso.es" style="color:var(--accent-primary);font-family:var(--font-sans);font-weight:600;font-size:0.95rem;text-decoration:none;">&larr; TLOTP</a>
   <span style="color:var(--text-secondary);font-family:var(--font-sans);font-size:0.85rem;">${epic_name} — TLOTP</span>
   <button onclick="toggleTheme()" style="background:none;border:1px solid var(--border-color);color:var(--text-secondary);padding:0.35rem 0.75rem;border-radius:6px;cursor:pointer;font-size:0.8rem;font-family:var(--font-sans);">&#x2600;&#xFE0F;/&#x1F319;</button>
 </header>
@@ -185,7 +188,7 @@ pre{font-family:var(--font-mono);white-space:pre-wrap;word-wrap:break-word;font-
 </head>
 <body>
 <header style="background:var(--bg-secondary);border-bottom:1px solid var(--border-color);padding:0.75rem 2rem;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100;">
-  <a href="/tlotp/" style="color:var(--accent-primary);font-family:var(--font-sans);font-weight:600;font-size:0.95rem;text-decoration:none;">&larr; TLOTP</a>
+  <a href="https://josemoreupeso.es" style="color:var(--accent-primary);font-family:var(--font-sans);font-weight:600;font-size:0.95rem;text-decoration:none;">&larr; TLOTP</a>
   <span style="color:var(--text-secondary);font-family:var(--font-sans);font-size:0.85rem;">${title} — TLOTP</span>
   <button onclick="toggleTheme()" style="background:none;border:1px solid var(--border-color);color:var(--text-secondary);padding:0.35rem 0.75rem;border-radius:6px;cursor:pointer;font-size:0.8rem;font-family:var(--font-sans);">&#x2600;&#xFE0F;/&#x1F319;</button>
 </header>
@@ -331,10 +334,12 @@ generate_index() {
 body{background:var(--bg-primary);color:var(--text-primary);font-family:var(--font-sans);line-height:1.6}
 
 /* Hero */
-.hero{text-align:center;padding:4rem 2rem 3rem;background:linear-gradient(180deg,var(--bg-secondary) 0%,var(--bg-primary) 100%)}
-.hero h1{font-family:Georgia,'Times New Roman',serif;font-size:2.5rem;color:#e8a838;margin-bottom:.5rem;letter-spacing:.05em}
-.hero .subtitle{color:var(--text-secondary);font-size:1.1rem;font-style:italic;margin-bottom:2rem}
-.hero .ring{font-size:.95rem;color:#cd7f32;border:1px solid var(--border-color);display:inline-block;padding:.5rem 1.5rem;border-radius:6px;margin-bottom:1.5rem;font-family:Georgia,serif;letter-spacing:.03em}
+.hero{text-align:center;padding:5rem 2rem 3.5rem;background:var(--bg-primary)}
+.hero h1{font-family:Georgia,'Times New Roman',serif;font-size:3.5rem;letter-spacing:.08em;margin-bottom:.6rem;background:linear-gradient(135deg,#00D9FF 0%,#00FFB3 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.hero .subtitle{color:#c9d1d9;font-size:1.25rem;font-weight:400;margin-bottom:1.5rem;letter-spacing:.02em}
+.hero .tagline{font-size:.95rem;color:var(--text-secondary);font-style:italic;margin-bottom:2.5rem;font-family:Georgia,serif}
+.btn-primary{display:inline-block;background:linear-gradient(135deg,#00D9FF 0%,#00FFB3 100%);color:#0D1117;padding:.75rem 2rem;border-radius:999px;text-decoration:none;font-weight:700;font-size:.95rem;font-family:var(--font-sans);transition:opacity .2s,transform .15s;border:none}
+.btn-primary:hover{opacity:.9;transform:translateY(-1px)}
 
 /* Main */
 .container{max-width:800px;margin:0 auto;padding:0 2rem}
@@ -362,8 +367,6 @@ body{background:var(--bg-primary);color:var(--text-primary);font-family:var(--fo
 
 /* CTA */
 .cta{text-align:center;margin:2.5rem 0}
-.cta a{display:inline-block;background:#e8a838;color:#0d0d0d;padding:.8rem 2rem;border-radius:6px;text-decoration:none;font-weight:600;font-size:1rem;font-family:var(--font-sans);transition:background .2s}
-.cta a:hover{background:#f0b848}
 .cta-secondary{display:block;margin-top:1rem}
 .cta-secondary a{color:var(--text-secondary);font-size:.85rem;text-decoration:none}
 .cta-secondary a:hover{color:var(--text-primary);text-decoration:underline}
@@ -377,15 +380,15 @@ body{background:var(--bg-primary);color:var(--text-primary);font-family:var(--fo
 <body>
 
 <header style="background:var(--bg-secondary);border-bottom:1px solid var(--border-color);padding:0.75rem 2rem;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100;">
-  <a href="/tlotp/" style="color:var(--accent-primary);font-family:var(--font-sans);font-weight:600;font-size:0.95rem;text-decoration:none;">&larr; TLOTP</a>
+  <a href="https://josemoreupeso.es" style="color:var(--accent-primary);font-family:var(--font-sans);font-weight:600;font-size:0.95rem;text-decoration:none;">&larr; TLOTP</a>
   <span style="color:var(--text-secondary);font-family:var(--font-sans);font-size:0.85rem;">TLOTP — The Lord of the Prompt</span>
   <button onclick="toggleTheme()" style="background:none;border:1px solid var(--border-color);color:var(--text-secondary);padding:0.35rem 0.75rem;border-radius:6px;cursor:pointer;font-size:0.8rem;font-family:var(--font-sans);">&#x2600;&#xFE0F;/&#x1F319;</button>
 </header>
 
 <div class="hero">
-  <div class="ring">One Prompt to Rule Them All</div>
   <h1>TLOTP</h1>
   <p class="subtitle">The Lord of the Prompt</p>
+  <p class="tagline">One Prompt to Rule Them All</p>
 </div>
 
 <div class="container">
@@ -468,7 +471,7 @@ body{background:var(--bg-primary);color:var(--text-primary);font-family:var(--fo
 
   <!-- Descarga -->
   <div class="cta">
-    <a href="tlotp-full.md" download="tlotp-full.md">Descargar prompt completo (tlotp-full.md)</a>
+    <a class="btn-primary" href="tlotp-full.md" download="tlotp-full.md">Descargar prompt completo</a>
     <div class="cta-secondary">
       <a href="https://github.com/joseguillermomoreu-gif/tlotp">Ver en GitHub</a>
     </div>


### PR DESCRIPTION
## ⚔️ Tres mejoras en una forja (+ bonus hero)

Cierra #331.

## 📦 Cambios

| Archivo | Cambio |
|---------|--------|
| `.github/workflows/semver.yml` | Lee versión desde `prompts/VERSION.md` en lugar de calcular desde commits. Guard de idempotencia para no duplicar tags. |
| `scripts/compile.sh` | `@prompts/ruta.md` → enlaces clickables a `josemoreupeso.es/tlotp/`. Hero del `index.html` con gradiente cyan/verde y botón pill. Links "volver" → `https://josemoreupeso.es` en todas las páginas. |
| `prompts/gandalf/gandalf-main.md` | Mini-guía actualizada con flujo real de Agent Teams y tabla de nombres de lore por especialidad. |

## ✨ Highlights

- **Semver corregido**: tag de GitHub = versión de `VERSION.md` siempre
- **@imports navegables**: las referencias `@prompts/` en el HTML son ahora enlaces reales
- **Hero index.html**: estilo visual alineado con `josemoreupeso.es` (gradiente, pill button)
- **Link volver**: apunta a `https://josemoreupeso.es` en todas las páginas generadas
- **Gandalf mini-guía**: refleja el flujo real con/sin Agent Teams y nombres de lore

🤖 Generated with [Claude Code](https://claude.com/claude-code)