### PR TITLE
feat(celebrimbor): avisar consumo de contexto y ofrecer desinstalación de GSD

### DIFF
--- a/prompts/celebrimbor/sections/15-module-gsd-detector.md
+++ b/prompts/celebrimbor/sections/15-module-gsd-detector.md
@@ -32,7 +32,7 @@ ls ~/.claude/commands/gsd:*.md 2>/dev/null
 
 ## Caso 1: GSD Instalado
 
-Si se detectan ficheros en algun scope, mostrar informe breve y continuar:
+Si se detectan ficheros en algun scope, mostrar informe breve:
 
 ```
   ✅ GSD detectado ({scope})
@@ -41,7 +41,125 @@ Si se detectan ficheros en algun scope, mostrar informe breve y continuar:
 
 Donde `{scope}` es `local`, `global` o `local + global` segun corresponda.
 
-**No interrumpir el flujo** — continuar directamente al siguiente paso.
+### Aviso de consumo de contexto
+
+Tras el mensaje de deteccion, mostrar el siguiente aviso:
+
+```
+══════════════════════════════════════════════════════════════
+⚠️  GSD ocupa contexto en cada sesion
+══════════════════════════════════════════════════════════════
+  Ten en cuenta que tener GSD instalado carga sus comandos en
+  el contexto de cada sesion, incluso cuando no lo estas usando.
+
+  Si no tienes previsto usar GSD, es recomendable desinstalarlo
+  para liberar ese espacio de contexto.
+══════════════════════════════════════════════════════════════
+```
+
+### Opciones al usuario
+
+```json
+{
+  "questions": [{
+    "header": "Celebrimbor — GSD instalado",
+    "question": "⚒️ ¿Que quieres hacer con GSD?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Mantener GSD instalado",
+        "description": "Lo uso o tengo previsto usarlo"
+      },
+      {
+        "label": "🗑️ Desinstalar GSD",
+        "description": "Quiero liberar contexto de mis sesiones"
+      },
+      {
+        "label": "⏭️ Continuar sin cambios",
+        "description": "Decidir mas tarde"
+      }
+    ]
+  }]
+}
+```
+
+### Routing de opciones
+
+#### Mantener GSD instalado
+
+Mostrar confirmacion breve y continuar al siguiente paso:
+
+```
+  ✅ GSD se mantiene en el taller. Las forjas siguen encendidas.
+```
+
+#### Desinstalar GSD
+
+Resolver el comando segun el `{scope}` donde GSD fue detectado:
+
+| Scope detectado | Comando a ejecutar |
+|-----------------|--------------------|
+| `local` | `rm .claude/commands/gsd:*.md` |
+| `global` | `rm ~/.claude/commands/gsd:*.md` |
+| `local + global` | `rm .claude/commands/gsd:*.md ~/.claude/commands/gsd:*.md` |
+
+**Paso 1 — Previsualizacion del comando**
+
+Mostrar al usuario el comando exacto que se va a ejecutar:
+
+```
+══════════════════════════════════════════════════════════════
+🗑️  Desinstalacion de GSD ({scope})
+══════════════════════════════════════════════════════════════
+  Se ejecutara el siguiente comando:
+    {comando_resuelto}
+
+  Esto eliminara todos los ficheros `gsd:*.md` del scope
+  detectado. La accion no es reversible desde Celebrimbor.
+══════════════════════════════════════════════════════════════
+```
+
+**Paso 2 — Confirmacion explicita**
+
+```json
+{
+  "questions": [{
+    "header": "Celebrimbor — Confirmar desinstalacion",
+    "question": "🗑️ ¿Confirmas la desinstalacion de GSD?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Si, desinstalar",
+        "description": "Ejecutar el comando mostrado"
+      },
+      {
+        "label": "🚫 Cancelar",
+        "description": "No tocar nada y continuar"
+      }
+    ]
+  }]
+}
+```
+
+**Paso 3 — Ejecucion y resultado**
+
+- Si el usuario confirma → ejecutar el comando resuelto.
+  - Si exito → mostrar:
+    ```
+      ✅ GSD desinstalado ({scope}). Contexto liberado.
+         Las forjas de Eregion recuperan su silencio.
+    ```
+  - Si error → mostrar el error y continuar sin bloquear el flujo.
+- Si el usuario cancela → mostrar:
+  ```
+    ⏭️ Desinstalacion cancelada. GSD se mantiene en el taller.
+  ```
+
+Continuar al siguiente paso.
+
+#### Continuar sin cambios
+
+Continuar directamente al siguiente paso sin accion ni mensajes adicionales.
 
 ---
 
@@ -125,9 +243,10 @@ Continuar directamente al siguiente paso sin accion.
 ## Reglas de ejecucion
 
 1. **Siempre ejecutar** durante el arranque, despues de la deteccion de Node.js
-2. **Rapido y silencioso** si GSD esta presente (una linea, sin interrupcion)
+2. **Transparente sobre el coste** si GSD esta presente (aviso de contexto + opcion de desinstalar)
 3. **Informativo pero no bloqueante** si GSD no esta presente (el usuario puede saltar)
-4. **No modificar** ningun otro modulo ni flujo existente de Celebrimbor
+4. **Destructivo solo bajo doble confirmacion**: cualquier desinstalacion requiere previsualizacion del comando y confirmacion explicita
+5. **No modificar** ningun otro modulo ni flujo existente de Celebrimbor
 
 ---
 


### PR DESCRIPTION
## Resumen

Amplía el **Caso 1** del detector de GSD en Celebrimbor (`15-module-gsd-detector.md`) para que, cuando GSD esté instalado, se advierta al usuario del consumo de contexto que implica y se le ofrezca la posibilidad de desinstalarlo.

Closes #390

## Cambios

- **Aviso de consumo de contexto** tras el mensaje de detección existente.
- **`questions` con tres opciones**: Mantener / Desinstalar / Continuar sin cambios.
- **Sub-flujo de desinstalación** con:
  - Resolución del comando según scope detectado (`local`, `global`, `local + global`).
  - Previsualización del comando exacto.
  - Segundo `questions` de confirmación explícita antes del `rm`.
  - Mensaje de resultado (éxito o error) tras la ejecución.
- **Actualización de la sección "Reglas de ejecución"** para reflejar el nuevo comportamiento transparente en Caso 1 y la regla de doble confirmación para acciones destructivas.
- **Caso 2 (GSD no instalado) intacto**.

## Criterios de aceptación del issue

- [x] El aviso de consumo de contexto aparece **solo** cuando GSD está instalado
- [x] La opción de desinstalación se ofrece tras el aviso
- [x] Celebrimbor muestra el comando/acción exacta antes de desinstalar
- [x] Se pide confirmación explícita antes de ejecutar la desinstalación
- [x] El scope de desinstalación coincide con el de la instalación detectada
- [x] Tras desinstalar, se confirma el resultado al usuario
- [x] Si el usuario elige mantener o saltar, el flujo de Celebrimbor continúa sin interrupciones

## Archivos tocados

- `prompts/celebrimbor/sections/15-module-gsd-detector.md` (+123 / -4)

## Plan de pruebas

- [ ] Ejecutar Celebrimbor en un entorno con GSD instalado **global** → verificar aviso, menú y que desinstalar usa `rm ~/.claude/commands/gsd:*.md`
- [ ] Ejecutar Celebrimbor en un entorno con GSD instalado **local** → verificar que desinstalar usa `rm .claude/commands/gsd:*.md`
- [ ] Ejecutar Celebrimbor en un entorno con GSD instalado en **ambos scopes** → verificar que desinstalar toca ambos
- [ ] Ejecutar Celebrimbor sin GSD instalado → verificar que **no** aparece ningún aviso ni menú nuevo (Caso 2 intacto)
- [ ] Verificar que elegir "Mantener" o "Continuar sin cambios" continúa el flujo sin interrupciones
- [ ] Verificar que tras elegir "Desinstalar" y cancelar en la confirmación, GSD sigue instalado