### PR TITLE
fix(compile): absolute URL as anchor display text avoids /prompts/ 404 (#396)

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -245,9 +245,10 @@ generate_html() {
     is_main=true
   fi
 
-  # Pipeline: raw md → placeholders → escape_html → restore links
-  # 5 steps: Step 0 (backtick-wrapped) → Step 1 (normal refs, fenced-aware)
-  #           → Step 2 (escape_html) → Step 3a (restore code refs) → Step 3b (restore normal refs)
+  # Pipeline: raw md → placeholders → escape_html → restore links → scrub
+  # 6 steps: Step 0 (backtick-wrapped) → Step 1 (normal refs, fenced-aware)
+  #           → Step 2 (escape_html) → Step 3a (restore code refs)
+  #           → Step 3b (restore normal refs) → Step 3c (scrub residual @prompts/)
   local raw_content
   raw_content="$(cat "$md_file")"
 
@@ -286,10 +287,22 @@ generate_html() {
   content="$(escape_html <<< "$raw_content")"
 
   # Step 3a: Restore TLOTP_CODE_IMPORT placeholders → <code><a href>
-  content="$(sed 's|TLOTP_CODE_IMPORT{\([^}]*\)}END|<code><a href="https://josemoreupeso.es/tlotp/\1.html" style="color:var(--accent-primary)">@prompts/\1.md</a></code>|g' <<< "$content")"
+  # INVARIANT (issue #396): display text MUST equal the href (absolute URL).
+  # If they diverge, LLMs reading the HTML may prioritize the visible text
+  # and reconstruct a wrong URL (e.g. concatenating "@prompts/..." to the base).
+  content="$(sed 's|TLOTP_CODE_IMPORT{\([^}]*\)}END|<code><a href="https://josemoreupeso.es/tlotp/\1.html" style="color:var(--accent-primary)">https://josemoreupeso.es/tlotp/\1.html</a></code>|g' <<< "$content")"
 
   # Step 3b: Restore TLOTP_IMPORT placeholders → <a href> (normal links)
-  content="$(sed 's|TLOTP_IMPORT{\([^}]*\)}END|<a href="https://josemoreupeso.es/tlotp/\1.html" style="color:var(--accent-primary)">@prompts/\1.md</a>|g' <<< "$content")"
+  # Same invariant as 3a: display text = href (absolute URL). See issue #396.
+  content="$(sed 's|TLOTP_IMPORT{\([^}]*\)}END|<a href="https://josemoreupeso.es/tlotp/\1.html" style="color:var(--accent-primary)">https://josemoreupeso.es/tlotp/\1.html</a>|g' <<< "$content")"
+
+  # Step 3c: Scrub any residual @prompts/X/Y.md literal (from fenced code blocks
+  # where Step 0/1 intentionally skipped processing) and replace with the
+  # absolute URL. Prevents LLMs from reconstructing the wrong URL from plain-text
+  # tokens inside <pre>/<code> fenced blocks. See issue #396.
+  # Character class excludes space, backtick, double-quote and '<' to avoid
+  # crossing word boundaries, already-generated anchors or HTML tags.
+  content="$(sed 's|@prompts/\([^[:space:]`"<]*\)\.md|https://josemoreupeso.es/tlotp/\1.html|g' <<< "$content")"
 
   # Meta description: first 500 chars of raw content, HTML-attr-safe
   local meta_description


### PR DESCRIPTION
## Summary

Fix para el bug [#396] donde cargar cualquier épica desde el menú principal de TLOTP producía un 404. El compilador generaba anchors cuyo texto visible (`@prompts/X/Y.md`) divergía del `href` (URL absoluta correcta). El LLM, al leer el HTML, priorizaba el texto visible y reconstruía una URL errónea con un segmento `/prompts/` indebido.

## Causa raíz

- `scripts/compile.sh` Step 3a/3b (líneas 289/292) generaba:
  `<a href="https://.../palantir-main.html">@prompts/palantir/palantir-main.md</a>`
  HREF correcto pero display text con `@prompts/` literal.
- Dentro de fenced code blocks (p.ej. la sección "Acceso Directo" del menú), las refs quedaban como **texto plano sin enlace**, con el token `@prompts/` intacto.

## Solución (Opción C: display text = URL absoluta)

Tres cambios en `scripts/compile.sh`:

1. **Step 3a modificado**: display text del `<code><a>` = URL absoluta idéntica al `href`.
2. **Step 3b modificado**: idem para el `<a>` sin `<code>`.
3. **Step 3c nuevo**: `sed` que sanea cualquier `@prompts/X/Y.md` residual (proveniente de fenced blocks) sustituyéndolo por la URL absoluta en texto plano.

**Invariante clave**: en todo anchor generado, `href == display text` → el LLM no tiene que inferir nada, la URL visible es la que debe fetchear.

## Alcance

- Solo se modifica `scripts/compile.sh` (18 inserciones, 5 eliminaciones)
- `prompts/**` **intocable** — los `@imports` internos siguen funcionando para el CLI de Claude Code y el CI `check-internal-links`
- Sin cambios en workflows, verify-compile.sh ni otros scripts

## Verificaciones locales

- `bash scripts/compile.sh` → 83 HTML generados sin error
- `grep -rF '@prompts/' dist/ --include='*.html'` → **cero coincidencias** (R5 del SDD)
- `dist/tlotp-main.html` contiene la URL absoluta `https://josemoreupeso.es/tlotp/palantir/palantir-main.html` tanto en `href` como en el texto visible de los anchors y en el texto plano del fenced block "Acceso Directo"
- Inspección manual: los anchors de las líneas 272 y 448 muestran `href == display text`
- Las 6 épicas (palantir, bardo, celebrimbor, ents, aragorn, gandalf) están correctamente reescritas uniformemente

## SDD

El diseño completo está en `.claude/sdd/396-fix-compile-url-prompts-prefix/`:
- `requirements.md` — 8 requisitos EARS + 6 no funcionales
- `design.md` — diagrama Mermaid AS-IS vs TO-BE, 2 ADRs, 6 riesgos técnicos
- `tasks.md` — 10 tareas con acceptance criteria verificables

## Follow-up (fuera de alcance)

Durante la implementación se detectó que `dist/tlotp-full.md` (Markdown concatenado servido en `https://josemoreupeso.es/tlotp/tlotp-full.md`) también contiene referencias `@prompts/X/Y.md` dentro de fenced blocks. Es el mismo bug conceptual pero en otro pipeline (`resolve_imports` en lugar de `generate_html`). El SDD aprobado se limitó al pipeline HTML, así que este hallazgo queda registrado como candidato a un issue/PR separado si se considera necesario.

## Test plan

- [ ] Revisar el diff de `scripts/compile.sh` (única modificación)
- [ ] Verificar que los checks de CI están en verde (markdown-lint · check-internal-links · check-external-links · lint-imports · compile-check)
- [ ] Opcional: compilar localmente con `bash scripts/compile.sh` y verificar que `grep -rF '@prompts/' dist/**/*.html` no encuentra nada
- [ ] Tras merge a `develop` (manual), cuando llegue a `master` y se despliegue, reproducir el flujo del issue: cargar TLOTP desde la CLI, seleccionar Palantír y confirmar que carga sin 404

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code) via TLOTP Agent