### PR TITLE
fix(compile): resolve @imports in HTML so banners are included

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -250,7 +250,7 @@ generate_html() {
   #           → Step 2 (escape_html) → Step 3a (restore code refs)
   #           → Step 3b (restore normal refs) → Step 3c (scrub residual @prompts/)
   local raw_content
-  raw_content="$(cat "$md_file")"
+  raw_content="$(resolve_imports "$md_file")"
 
   # Step 0 + Step 1: Line-by-line loop with in_fenced tracking
   # Step 0: Detect `@prompts/path.md` (backtick-wrapped) → TLOTP_CODE_IMPORT{path}END


### PR DESCRIPTION
## Summary

- `generate_html()` in `compile.sh` now calls `resolve_imports()` instead of `cat`, so `@import` lines in epic `*-main.md` files are resolved before HTML generation
- This ensures banners defined in imported sections are present in the compiled HTML served via WebFetch
- Matches the existing behavior of `compile_full_md()` which already used `resolve_imports()`

Closes #403

## Test plan

- [x] `compile.sh` runs successfully (81 HTML files)
- [x] `verify-compile.sh` passes all checks
- [x] Banner text (e.g. `G A N D A L F`) is present in `gandalf/gandalf-main.html`
- [x] Banner text (e.g. `P A L A N T`) is present in `palantir/palantir-main.html`