### PR TITLE
fix(release-prep): scope sed to preserve historical VERSION.md entries

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -108,12 +108,17 @@ jobs:
           RELEASE_NAME="${{ inputs.release_name }}"
           TODAY=$(date +%Y-%m-%d)
 
-          # Actualizar versión actual en la sección "Versión Actual"
-          sed -i "s/\*\*TLOTP v[0-9]\+\.[0-9]\+\.[0-9]\+\*\*/**TLOTP ${NEW_VERSION}**/" prompts/VERSION.md
-          sed -i "s/^- \*\*Fecha release\*\*:.*$/- **Fecha release**: ${TODAY}/" prompts/VERSION.md
+          # Scope sed to "Versión Actual" section only (between header and first ---)
+          # to avoid overwriting historical entries. See issue #401.
+          sed -i '/^## .*Versi.n Actual/,/^---$/ {
+            s/\*\*TLOTP v[0-9]\+\.[0-9]\+\.[0-9]\+\*\*/**TLOTP '"${NEW_VERSION}"'**/
+            s/^- \*\*Fecha release\*\*:.*$/- **Fecha release**: '"${TODAY}"'/
+          }' prompts/VERSION.md
 
           if [ -n "$RELEASE_NAME" ]; then
-            sed -i "s/^- \*\*Nombre código\*\*:.*$/- **Nombre código**: \"${RELEASE_NAME}\"/" prompts/VERSION.md
+            sed -i '/^## .*Versi.n Actual/,/^---$/ {
+              s/^- \*\*Nombre código\*\*:.*$/- **Nombre código**: "'"${RELEASE_NAME}"'"/
+            }' prompts/VERSION.md
           fi
 
           echo "✅ VERSION.md actualizado a ${NEW_VERSION}"

--- a/prompts/VERSION.md
+++ b/prompts/VERSION.md
@@ -26,7 +26,7 @@
 
 ### v5.0.0 — "The Two Towers of the Web"
 - **Fecha release**: 2026-04-15
-- **Nombre código**: "The Unbarred Gate"
+- **Nombre código**: "The Fellowship Assembled"
 
 ### v4.0.0 — "El Mago Blanco"
 - **Fecha release**: 2026-04-15


### PR DESCRIPTION
## Summary

- Scoped the 3 `sed` commands in `release-prep.yml` to only operate within the "Versión Actual" section (between its header and first `---`), preventing historical changelog entries from being overwritten
- Restored v5.0.0 historical entry name from "The Unbarred Gate" (incorrectly set by v6.1.0 release) back to its correct "The Fellowship Assembled"

Closes #401

## Test plan

- [x] Dry-run `sed` with range on a copy of VERSION.md: "Versión Actual" fields are updated, historical entries remain untouched
- [x] v5.0.0 entry verified to show "The Fellowship Assembled"
- [ ] CI passes on PR