### PR TITLE
fix(config): cambiar entry point WebFetch de tlotp-full a tlotp-main

### DIFF
--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -174,7 +174,7 @@ Mostrar el siguiente bloque educativo (sin interacción):
 
      3. Reinvoca TLOTP con:
 
-        WebFetch https://josemoreupeso.es/tlotp/tlotp-full.md
+        WebFetch https://josemoreupeso.es/tlotp/tlotp-main.html
 
   💍 Por ahora, pon tu confianza en Gandalf y continúa —
      la aventura no se detiene aquí.


### PR DESCRIPTION
## Summary

- Cambia la referencia interna en `prompts/tlotp-main.md` de `tlotp-full.md` (~8500 lineas) a `tlotp-main.html` (~400 lineas) como punto de entrada WebFetch
- El prompt completo era tan grande que los LLMs lo resumian en lugar de seguirlo, perdiendo fidelidad
- Con el entry point ligero, el LLM carga progresivamente solo las epicas que el usuario selecciona

## Cambios fuera del repo

- Editado `~/.claude/rules/tlotp.md` (fichero local del usuario) para apuntar a `tlotp-main.html`

## Test plan

- [ ] Verificar que `https://josemoreupeso.es/tlotp/tlotp-main.html` responde correctamente
- [ ] Probar que un LLM puede hacer WebFetch a la URL y seguir las instrucciones sin resumirlas
- [ ] Verificar que el routing a epicas funciona (las URLs de epic-main.md se resuelven correctamente)

Closes #416