### PR TITLE
feat(ci): verify internal hrefs in compiled HTML before deploy

### DIFF
--- a/scripts/verify-compile.sh
+++ b/scripts/verify-compile.sh
@@ -145,6 +145,87 @@ for epic in palantir ents celebrimbor bardo aragorn gandalf; do
   fi
 done
 
+# 9. Verify internal hrefs in compiled HTML resolve to existing files in dist/
+#    (see SDD .claude/sdd/423-ci-verify-internal-links/ · issue #423)
+#
+#    For each href="..." in any dist/**/*.html:
+#      - Ignore fragments (#...), mailto:, javascript:, data:
+#      - Ignore external URLs (http(s):// to another domain)
+#      - URLs to own site (https://josemoreupeso.es/tlotp/PATH) → check dist/PATH
+#      - Relative paths → resolve against the HTML's own directory
+#      - Strip query (?...) and fragment (#...) before checking
+#      - Trailing '/' or directory → require <path>/index.html
+check_internal_hrefs() {
+  local total=0
+  local files=0
+  local href_errors=0
+  local html
+  local href
+  local target
+  local html_dir
+  local rel_from_dist
+
+  while IFS= read -r html; do
+    files=$((files + 1))
+    html_dir="$(dirname "$html")"
+    while IFS= read -r href; do
+      total=$((total + 1))
+
+      # Skip non-navigational schemes and fragments
+      case "$href" in
+        \#*|mailto:*|javascript:*|data:*|tel:*)
+          continue
+          ;;
+      esac
+
+      # Strip fragment and query
+      href="${href%%#*}"
+      href="${href%%\?*}"
+      [ -z "$href" ] && continue
+
+      # Classify
+      case "$href" in
+        https://josemoreupeso.es/tlotp/*)
+          target="$DIST_DIR/${href#https://josemoreupeso.es/tlotp/}"
+          ;;
+        http://*|https://*|//*)
+          # External → ignore
+          continue
+          ;;
+        /*)
+          # Absolute path on host (unexpected in TLOTP; treat as dist-root)
+          target="$DIST_DIR${href}"
+          ;;
+        *)
+          # Relative → resolve against html_dir
+          target="$html_dir/$href"
+          ;;
+      esac
+
+      # Directory or trailing slash → require index.html
+      if [ -d "$target" ] || [ "${target: -1}" = "/" ]; then
+        target="${target%/}/index.html"
+      fi
+
+      if [ ! -f "$target" ]; then
+        rel_from_dist="${html#$DIST_DIR/}"
+        echo "  ERROR: broken href in ${rel_from_dist} -> ${href}"
+        href_errors=$((href_errors + 1))
+      fi
+    done < <(grep -oE 'href="[^"]+"' "$html" 2>/dev/null | sed -E 's/^href="([^"]+)"$/\1/' || true)
+  done < <(find "$DIST_DIR" -name '*.html' -type f)
+
+  echo "  Checked $total href(s) across $files html file(s)"
+  if [ "$href_errors" -gt 0 ]; then
+    echo "::error::$href_errors broken internal href(s) found in dist/"
+    errors=$((errors + href_errors))
+  else
+    echo "  [OK] All internal hrefs resolve in dist/"
+  fi
+}
+
+check_internal_hrefs
+
 echo ""
 if [ "$errors" -gt 0 ]; then
   echo "FAILED: $errors error(s) detected"


### PR DESCRIPTION
## Summary

Closes part of the gap revealed by #422: until now the CI verified `@prompts/` in source `.md` files but **never checked that the `href` attributes in compiled `dist/**/*.html` actually resolved**. A broken `href` generated by `compile.sh` would only surface in production (404s on `/{epic}/` were a real example).

This PR extends `scripts/verify-compile.sh` with a new check #9 — `check_internal_hrefs` — that runs in both CI (`ci.yml → compile-check`) and Deploy (`deploy.yml` before `rsync`), so a broken link cannot reach production.

## What it does

For every `href="..."` found in `dist/**/*.html`:

| Case | Behaviour |
|------|-----------|
| `https://josemoreupeso.es/tlotp/PATH` | Check `dist/PATH` exists |
| Relative (`./foo`, `foo/bar.html`) | Resolve against the HTML's own directory |
| External (`http(s)://other-domain/...`) | **Ignore** |
| Fragment `#anchor`, `mailto:`, `javascript:`, `data:`, `tel:` | **Ignore** |
| Trailing `/` or directory | Require `<path>/index.html` (catches #422) |
| `?query` and `#fragment` | Stripped before resolving |

No new dependencies — pure bash + grep + find + sed, same style as the existing 8 checks in the script.

## Local validation

- Baseline: `bash scripts/compile.sh && bash scripts/verify-compile.sh` → **8796 hrefs verified across 96 HTML files, OK**
- Artificial broken absolute href → detected with `::error::`
- Artificial broken relative href → detected
- Artificial `fake-dir/` (exact #422 pattern) → detected
- External / anchor / mailto → correctly ignored
- Trailing `/` with existing `index.html` (e.g. `palantir/`) → passes

## SDD

Full Spec-Driven Document in [`.claude/sdd/423-ci-verify-internal-links/`](https://github.com/joseguillermomoreu-gif/tlotp/tree/feature/t423_ci_verify_internal_links/.claude/sdd/423-ci-verify-internal-links) (will be committed alongside other SDDs as their own tasks land).

## Test plan

- [ ] CI `markdown-lint` green
- [ ] CI `check-internal-links` green
- [ ] CI `check-external-links` green
- [ ] CI `lint-imports` green
- [ ] CI `compile-check` green — this is the job that now runs the new `check_internal_hrefs`
- [ ] Manual review of the diff in `scripts/verify-compile.sh`

Refs #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)