### PR TITLE
feat(ci): smoke test post-deploy of key public URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,3 +64,22 @@ jobs:
             exit 1
           fi
           echo "Health check passed — HTTP 200 and body contains 'TLOTP'"
+
+      # Post-deploy smoke test — verify every URL in scripts/smoke-urls.txt
+      # responds HTTP 200. Catches deploys where the root serves fine but
+      # épica indexes or main prompts are broken (see issues #422, #424).
+      - name: Smoke test public URLs
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: >
+            --verbose
+            --no-progress
+            --timeout 20
+            --max-retries 3
+            --retry-wait-time 5
+            --accept 200
+            --
+            scripts/smoke-urls.txt
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/smoke-test-local.sh
+++ b/scripts/smoke-test-local.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════════════
+#   smoke-test-local.sh — Smoke test de URLs públicas de TLOTP
+#
+#   Lee scripts/smoke-urls.txt y comprueba que cada URL devuelve
+#   HTTP 200. Uso local para validar el sitio desplegado antes
+#   de un merge a master (opcional) o para diagnosticar fallos
+#   post-deploy sin esperar al CI.
+#
+#   Exit code:
+#     0 → todas las URLs responden 200
+#     1 → alguna URL falló (status != 200 tras reintentos)
+# ═══════════════════════════════════════════════════════════════
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+URLS_FILE="$SCRIPT_DIR/smoke-urls.txt"
+
+if [ ! -f "$URLS_FILE" ]; then
+  echo "ERROR: $URLS_FILE not found"
+  exit 2
+fi
+
+MAX_RETRIES=3
+RETRY_WAIT=5
+TIMEOUT=20
+
+errors=0
+total=0
+
+echo "=== TLOTP Smoke Test (local) ==="
+echo ""
+
+while IFS= read -r url; do
+  # Skip comments and blank lines
+  case "$url" in
+    ''|\#*) continue ;;
+  esac
+
+  total=$((total + 1))
+  code=""
+  attempt=0
+  while [ "$attempt" -lt "$MAX_RETRIES" ]; do
+    attempt=$((attempt + 1))
+    code=$(curl -s -L -o /dev/null -w '%{http_code}' \
+      --max-time "$TIMEOUT" "$url" 2>/dev/null || echo "000")
+    if [ "$code" = "200" ]; then
+      break
+    fi
+    if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+      sleep "$RETRY_WAIT"
+    fi
+  done
+
+  if [ "$code" = "200" ]; then
+    echo "  [OK]    $code  $url"
+  else
+    echo "  ERROR   $code  $url  (after $attempt attempts)"
+    errors=$((errors + 1))
+  fi
+done < "$URLS_FILE"
+
+echo ""
+if [ "$errors" -gt 0 ]; then
+  echo "FAILED: $errors/$total URL(s) did not return 200"
+  exit 1
+else
+  echo "OK: $total URL(s) verified"
+fi

--- a/scripts/smoke-urls.txt
+++ b/scripts/smoke-urls.txt
@@ -1,0 +1,32 @@
+# ═══════════════════════════════════════════════════════════════
+#   smoke-urls.txt — URLs críticas del sitio TLOTP
+#
+#   Lista declarativa, single-source-of-truth para:
+#     1. CI post-deploy (.github/workflows/deploy.yml → lychee)
+#     2. Dev local         (scripts/smoke-test-local.sh → curl)
+#
+#   Formato:
+#     - Una URL por línea (HTTPS).
+#     - Comentarios con '#' (lychee y smoke-test-local.sh los ignoran).
+#     - Líneas vacías permitidas.
+#
+#   Mantener sincronizado con EPIC_ORDER de scripts/compile.sh.
+# ═══════════════════════════════════════════════════════════════
+
+# Raíz y prompt agregado
+https://josemoreupeso.es/tlotp/index.html
+https://josemoreupeso.es/tlotp/tlotp-main.html
+https://josemoreupeso.es/tlotp/tlotp-full.md
+
+# Índices por épica (patrón #422: "/{epic}/" servido por el back-end)
+https://josemoreupeso.es/tlotp/palantir/index.html
+https://josemoreupeso.es/tlotp/ents/index.html
+https://josemoreupeso.es/tlotp/celebrimbor/index.html
+https://josemoreupeso.es/tlotp/aragorn/index.html
+https://josemoreupeso.es/tlotp/bardo/index.html
+https://josemoreupeso.es/tlotp/gandalf/index.html
+
+# Canarios — main prompt de una épica en ambos formatos
+# (sirven como smoke del pipeline compile.sh → dist → rsync)
+https://josemoreupeso.es/tlotp/palantir/palantir-main.html
+https://josemoreupeso.es/tlotp/palantir/palantir-main.md


### PR DESCRIPTION
## Summary

The existing health check in `deploy.yml` only hits `https://josemoreupeso.es/tlotp/index.html`. A broken deploy where the root serves fine but épica indexes or main prompts return 4xx (exactly the #422 scenario) would pass undetected.

This PR adds a post-deploy **smoke test** over a versioned list of key public URLs, running after the health check in the same `compile-and-deploy` job.

## What it does

**`scripts/smoke-urls.txt`** — declarative, single-source-of-truth list (11 URLs):
- Root + `tlotp-main.html` + `tlotp-full.md`
- 6 épica indexes (`palantir/index.html`, `ents/index.html`, …)
- Canaries: `palantir/palantir-main.html` and `palantir-main.md`

**`deploy.yml`** — new step `Smoke test public URLs` using `lychee-action`:
- `--accept 200 --max-retries 3 --retry-wait-time 5 --timeout 20`
- `fail: true` → the job fails if any URL does not return 200
- Pinned to the same SHA already used in `ci.yml` (`check-external-links`)

**`scripts/smoke-test-local.sh`** — dev wrapper (`curl` + retries) that reuses the same `.txt`. Zero duplication between CI and local.

## Local validation

- `bash scripts/smoke-test-local.sh` against production → **11/11 OK**
- Synthetic fixture with a bad URL → script returns exit 1 with `ERROR 404 …`

## SDD

Full SDD in [`.claude/sdd/424-ci-smoke-test-deploy-urls/`](https://github.com/joseguillermomoreu-gif/tlotp/tree/feature/t424_ci_smoke_test_deploy_urls/.claude/sdd/424-ci-smoke-test-deploy-urls) (will be committed with its own task as agreed).

## Test plan

- [ ] CI green (all 5 jobs — this PR doesn't touch the compile step, only `deploy.yml` and new scripts, so `ci.yml` should be a no-op)
- [ ] Once merged to `master` in the next release: the deploy workflow runs the new smoke step; verify that the 11 URLs are checked and the build is green
- [ ] Manual review of `scripts/smoke-urls.txt` to confirm coverage matches `EPIC_ORDER` in `compile.sh`

## Notes

- `deploy.yml` only runs on `master` (on merges that touch `prompts/**`, `VERSION.md` or `compile.sh`), so the new smoke step won't execute on this PR. It will run automatically on the next promotion to `master`.
- The pre-existing `Health check` step is preserved as defense-in-depth.

Refs #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)