### PR TITLE
feat(palantir): add Pépeton status line preset + informative banner

### DIFF
--- a/prompts/palantir/palantir-main.md
+++ b/prompts/palantir/palantir-main.md
@@ -27,6 +27,7 @@
 @prompts/palantir/sections/06b-exportar-visiones.md
 @prompts/palantir/sections/07a-status-line-create.md
 @prompts/palantir/sections/07b-status-line-manage.md
+@prompts/palantir/sections/07c-status-line-pepeton.md
 
 ---
 
@@ -42,6 +43,7 @@
 7b. **06b-exportar-visiones.md** - Exportar configuraciones + eliminar características
 8. **07a-status-line-create.md** - Detección + creación de Status Line (Caso A: no configurada)
 9. **07b-status-line-manage.md** - Gestión de Status Line existente (Caso B: editar / reemplazar / eliminar)
+10. **07c-status-line-pepeton.md** - Preset de Pépeton (Caso C: 2 líneas con barras de contexto, 5h y 7d)
 
 ---
 

--- a/prompts/palantir/sections/07a-status-line-create.md
+++ b/prompts/palantir/sections/07a-status-line-create.md
@@ -7,6 +7,37 @@
 
 ---
 
+## PASO 0: Banner informativo
+
+**Mostrar sin interacción** antes de cualquier otra acción del módulo:
+
+```
+══════════════════════════════════════════════════════════════════
+🔮 Palantír — Status Line
+
+  El Status Line de Claude Code es un script de shell que se ejecuta
+  en cada actualización y muestra lo que tú quieras en la barra inferior.
+
+  ✅ Palantír puede ayudarte a:
+     · Crear un Status Line desde cero (asistido o desde preset)
+     · Ver, editar o reemplazar el script actual
+     · Eliminar la configuración existente
+     · Consultar la documentación oficial en tiempo real
+
+  ❌ Palantír NO puede:
+     · Garantizar que tu terminal soporte colores ANSI o Nerd Fonts
+     · Acceder a datos que Claude Code no exponga en el JSON de entrada
+     · Configurar el Status Line de forma retroactiva para sesiones pasadas
+
+  💡 Campos disponibles en el JSON: model, workspace, cost, context_window,
+     rate_limits (Pro/Max), session_id, git_worktree, vim.mode y más.
+══════════════════════════════════════════════════════════════════
+```
+
+Tras mostrarlo, continuar al PASO 1.
+
+---
+
 ## PASO 1: Detección del estado
 
 **Leer silenciosamente** los siguientes ficheros (sin formatear ni mostrar nada todavía):
@@ -92,6 +123,10 @@ hora, o lo que tú decidas.
         "description": "Consultaré la documentación oficial y te haré unas preguntas"
       },
       {
+        "label": "🥔 Usar el status line de Pépeton, hijo de Móreuton",
+        "description": "Instalar el preset de 2 líneas (contexto · 5h · 7d)"
+      },
+      {
         "label": "📖 Ver docs primero",
         "description": "Fetchear la documentación oficial antes de decidir"
       },
@@ -105,6 +140,7 @@ hora, o lo que tú decidas.
 ```
 
 - **Sí, guíame** → PASO 4 (fetch) + PASO 5 (entrevista)
+- **🥔 Usar el status line de Pépeton** → cargar `@prompts/palantir/sections/07c-status-line-pepeton.md` y ejecutar PASO P1 (lore del preset)
 - **Ver docs primero** → PASO 4 y después preguntar de nuevo
 - **Volver** → cargar `@prompts/palantir/sections/00-menu-principal.md` PASO 2
 

--- a/prompts/palantir/sections/07b-status-line-manage.md
+++ b/prompts/palantir/sections/07b-status-line-manage.md
@@ -11,6 +11,37 @@
 # CASO B · Status Line ya configurada — Gestión
 # ═══════════════════════════════════════════════════
 
+## PASO 6b: Banner informativo
+
+**Mostrar sin interacción** antes de mostrar la configuración actual:
+
+```
+══════════════════════════════════════════════════════════════════
+🔮 Palantír — Status Line
+
+  El Status Line de Claude Code es un script de shell que se ejecuta
+  en cada actualización y muestra lo que tú quieras en la barra inferior.
+
+  ✅ Palantír puede ayudarte a:
+     · Crear un Status Line desde cero (asistido o desde preset)
+     · Ver, editar o reemplazar el script actual
+     · Eliminar la configuración existente
+     · Consultar la documentación oficial en tiempo real
+
+  ❌ Palantír NO puede:
+     · Garantizar que tu terminal soporte colores ANSI o Nerd Fonts
+     · Acceder a datos que Claude Code no exponga en el JSON de entrada
+     · Configurar el Status Line de forma retroactiva para sesiones pasadas
+
+  💡 Campos disponibles en el JSON: model, workspace, cost, context_window,
+     rate_limits (Pro/Max), session_id, git_worktree, vim.mode y más.
+══════════════════════════════════════════════════════════════════
+```
+
+Tras mostrarlo, continuar al PASO 7.
+
+---
+
 ## PASO 7: Mostrar configuración actual
 
 Para cada scope donde `STATUS_LINE_STATE[scope].exists == true`, mostrar:
@@ -51,14 +82,14 @@ y variables antes de editar.
 
 ---
 
-## PASO 9: Menú de gestión
+## PASO 9: Menú de gestión (paginado 3+1)
 
-**AskUserQuestion**:
+**Pantalla 1** (1/2 — mostrar primero) — `AskUserQuestion`:
 
 ```json
 {
   "questions": [{
-    "header": "Status Line · Gestión",
+    "header": "Status Line · Gestión (1/2)",
     "question": "¿Qué quieres hacer con tu Status Line?",
     "multiSelect": false,
     "options": [
@@ -75,13 +106,48 @@ y variables antes de editar.
         "description": "Quitar la configuración de Status Line (requerirá confirmación)"
       },
       {
-        "label": "🔙 Volver al menú de Palantír",
-        "description": ""
+        "label": "➕ Ver más...",
+        "description": "Presets y volver"
       }
     ]
   }]
 }
 ```
+
+**Si elige `➕ Ver más...`**, mostrar **Pantalla 2** (2/2):
+
+```json
+{
+  "questions": [{
+    "header": "Status Line · Gestión (2/2)",
+    "question": "¿Qué quieres hacer con tu Status Line?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🥔 Usar el status line de Pépeton, hijo de Móreuton",
+        "description": "Instalar el preset de 2 líneas (contexto · 5h · 7d)"
+      },
+      {
+        "label": "🔙 Volver al menú de Palantír",
+        "description": ""
+      },
+      {
+        "label": "⬅️ Volver a pantalla 1",
+        "description": "Editar · Reemplazar · Eliminar"
+      }
+    ]
+  }]
+}
+```
+
+**Routing**:
+
+- `✏️ Editar` → PASO 10 · Opción Editar
+- `🔄 Reemplazar desde cero` → PASO 10 · Opción Reemplazar
+- `🗑️ Eliminar` → PASO 10 · Opción Eliminar
+- `🥔 Usar el status line de Pépeton` → cargar `@prompts/palantir/sections/07c-status-line-pepeton.md` y ejecutar PASO P1
+- `🔙 Volver al menú de Palantír` → PASO 10 · Opción Volver
+- `⬅️ Volver a pantalla 1` → mostrar Pantalla 1 de nuevo
 
 ---
 

--- a/prompts/palantir/sections/07c-status-line-pepeton.md
+++ b/prompts/palantir/sections/07c-status-line-pepeton.md
@@ -1,0 +1,353 @@
+# 🥔 Status Line — Preset de Pépeton, Señor de las Tierras Paletas (Caso C)
+
+> **IMPORTADO POR**: `palantir-main.md`
+>
+> Módulo de instalación asistida de un Status Line preconfigurado: 2 líneas,
+> barras de contexto, ventana de 5h y uso semanal 7d. Forjado por Pépeton
+> hijo de Móreuton.
+
+---
+
+# ═══════════════════════════════════════════════════
+# CASO C · Preset de Pépeton
+# ═══════════════════════════════════════════════════
+
+> **Cuándo ejecutar**: cuando el usuario elige la opción
+> `🥔 Usar el status line de Pépeton, hijo de Móreuton` desde el menú de
+> creación (`07a`) o de gestión (`07b`).
+
+---
+
+## PASO P1 — Lore y descripción del preset
+
+Mostrar sin interacción:
+
+```
+══════════════════════════════════════════════════════════════════
+🥔 El Status Line de Pépeton, Señor de las Tierras Paletas
+
+  Forjado en las profundidades del código por Pépeton hijo de Móreuton,
+  este status line de 2 líneas lo tiene todo:
+
+  Línea 1 (identidad):
+    ~/dir  ·   branch  ·  Modelo  ·  $coste
+
+  Línea 2 (límites):
+    ████░░░░░░ 38% ctx  ·  ██░░░░░░░░ 22% 5h  ·  9% 7d
+
+  · Colores adaptativos: verde (<50%) · amarillo (50-79%) · rojo (≥80%)
+  · Requiere: jq, git, bash
+  · Barras de 5h y 7d solo visibles en cuentas Pro/Max (se ocultan si no aplica)
+══════════════════════════════════════════════════════════════════
+```
+
+---
+
+## PASO P2 — Verificar dependencias
+
+Ejecutar silenciosamente:
+
+```bash
+jq --version 2>/dev/null
+git --version 2>/dev/null
+```
+
+**Capturar** si cada comando existe:
+- `JQ_OK`  = true/false
+- `GIT_OK` = true/false
+
+### Si `JQ_OK == false`
+
+Mostrar advertencia y preguntar:
+
+```
+⚠️  Atención — jq no detectado
+
+  El status line de Pépeton usa `jq` para parsear el JSON que Claude Code
+  le pasa por stdin en cada actualización. Sin `jq`, el statusline
+  no funcionará aunque lo instalemos ahora.
+
+  💡 Instalación sugerida:
+     · 🐧 Linux/WSL:  sudo apt install jq
+     · 🍎 macOS:      brew install jq
+     · 🪟 Windows:    choco install jq  (o scoop install jq)
+```
+
+**AskUserQuestion**:
+
+```json
+{
+  "questions": [{
+    "header": "Dependencia · jq",
+    "question": "¿Cómo quieres proceder?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Continuar igualmente",
+        "description": "Instalaré jq más tarde; procede con el preset"
+      },
+      {
+        "label": "🚫 Cancelar",
+        "description": "Vuelve al menú de Palantír, instalaré jq primero"
+      }
+    ]
+  }]
+}
+```
+
+Si elige cancelar → volver al menú principal de Palantír.
+
+### Si `GIT_OK == false`
+
+Avisar (no bloqueante): el statusline ocultará la rama git si no hay git
+disponible. No preguntar; sólo mostrar:
+
+```
+ℹ️  git no detectado — la línea 1 no incluirá rama (el resto funciona).
+```
+
+---
+
+## PASO P3 — Detectar scope
+
+**Leer silenciosamente** ambos `settings.json`:
+
+- `~/.claude/settings.json` → `GLOBAL_HAS_STATUSLINE`
+- `.claude/settings.json` del proyecto actual → `PROJECT_HAS_STATUSLINE`
+
+### Matriz de decisión
+
+| Global | Proyecto | Opciones a ofrecer |
+|--------|----------|---------------------|
+| ❌     | ❌       | Instalar en **Global** / Instalar en **Proyecto** / Cancelar |
+| ✅     | ❌       | Reemplazar Global / Instalar Proyecto (prevalece) / Cancelar |
+| ❌     | ✅       | Instalar Global / Reemplazar Proyecto / Cancelar |
+| ✅     | ✅       | Reemplazar Global / Reemplazar Proyecto / Cancelar |
+
+**AskUserQuestion** con las opciones que apliquen (máximo 4 incluyendo cancelar).
+
+Si el usuario elige reemplazar algo existente, mostrar el valor actual antes
+de la confirmación final:
+
+```
+📊 Configuración actual ([scope])
+══════════════════════════════════════════════════════
+"statusLine": [valor exacto]
+══════════════════════════════════════════════════════
+
+Esta configuración será reemplazada por el preset de Pépeton.
+```
+
+**AskUserQuestion** de confirmación:
+
+```json
+{
+  "questions": [{
+    "header": "Confirmar reemplazo",
+    "question": "¿Procedemos con el reemplazo?",
+    "multiSelect": false,
+    "options": [
+      { "label": "✅ Sí, instalar preset de Pépeton", "description": "Escribir script + actualizar settings.json" },
+      { "label": "🚫 Cancelar", "description": "No tocar nada" }
+    ]
+  }]
+}
+```
+
+**Guardar en contexto**: `INSTALL_SCOPE` = `"global"` o `"project"`.
+
+---
+
+## PASO P4 — Escribir el script `statusline-command.sh`
+
+**Ruta destino** según scope:
+
+- `INSTALL_SCOPE == "global"`  → `$HOME/.claude/statusline-command.sh`
+- `INSTALL_SCOPE == "project"` → `.claude/statusline-command.sh`
+
+**Antes de escribir**: si la carpeta `.claude/` no existe en el scope elegido,
+crearla con Bash (`mkdir -p`).
+
+**Escribir con Write tool** exactamente este contenido:
+
+```bash
+#!/usr/bin/env bash
+# Claude Code status line — 2 líneas
+# Línea 1: dir · branch · modelo · coste
+# Línea 2: barra contexto · barra 5h · porcentaje 7d
+
+input=$(cat)
+
+model=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // ""')
+if [[ "$cwd" == "$HOME"* ]]; then
+  cwd_short="~${cwd#$HOME}"
+else
+  cwd_short="$cwd"
+fi
+
+git_branch=""
+if git -C "${cwd}" rev-parse --git-dir >/dev/null 2>&1; then
+  git_branch=$(git -C "${cwd}" branch --show-current 2>/dev/null)
+fi
+
+cost_usd=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+if [ -z "$cost_usd" ]; then
+  total_in=$(echo "$input" | jq -r '.context_window.total_input_tokens // 0')
+  total_out=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0')
+  cache_w=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+  cache_r=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+  cost_usd=$(echo "$total_in $total_out $cache_w $cache_r" | awk '{
+    printf "%.4f", ($1*3.00 + $2*15.00 + $3*3.75 + $4*0.30) / 1000000
+  }')
+fi
+cost_fmt=$(printf '$%.4f' "$cost_usd")
+
+ctx_pct=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+five_h=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+seven_d=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+
+GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'
+CYAN='\033[36m'; BLUE='\033[34m'; DIM='\033[2m'; RESET='\033[0m'
+
+make_bar() {
+  local pct=$1 width=${2:-10} filled empty bar f e
+  filled=$(( pct * width / 100 ))
+  empty=$(( width - filled ))
+  bar=""
+  [ "$filled" -gt 0 ] && printf -v f "%${filled}s" && bar="${f// /█}"
+  [ "$empty" -gt 0 ] && printf -v e "%${empty}s" && bar="${bar}${e// /░}"
+  printf '%s' "$bar"
+}
+
+bar_color() {
+  local pct=$1
+  if   [ "$pct" -ge 80 ]; then printf '%s' "$RED"
+  elif [ "$pct" -ge 50 ]; then printf '%s' "$YELLOW"
+  else                         printf '%s' "$GREEN"
+  fi
+}
+
+SEP="${DIM} · ${RESET}"
+
+dir_s="${GREEN}${cwd_short}${RESET}"
+model_s="${CYAN}${model}${RESET}"
+cost_s="${BLUE}${cost_fmt}${RESET}"
+
+if [ -n "$git_branch" ]; then
+  branch_s="${YELLOW}$(printf '\ue0a0') ${git_branch}${RESET}"
+  line1="${dir_s}${SEP}${branch_s}${SEP}${model_s}${SEP}${cost_s}"
+else
+  line1="${dir_s}${SEP}${model_s}${SEP}${cost_s}"
+fi
+
+ctx_bar=$(make_bar "$ctx_pct")
+ctx_color=$(bar_color "$ctx_pct")
+line2="${ctx_color}${ctx_bar}${RESET} ${ctx_pct}% ctx"
+
+if [ -n "$five_h" ]; then
+  five_h_int=$(printf '%.0f' "$five_h")
+  fh_bar=$(make_bar "$five_h_int")
+  fh_color=$(bar_color "$five_h_int")
+  line2="${line2}${SEP}${fh_color}${fh_bar}${RESET} ${five_h_int}% 5h"
+fi
+
+if [ -n "$seven_d" ]; then
+  seven_d_int=$(printf '%.0f' "$seven_d")
+  sd_color=$(bar_color "$seven_d_int")
+  line2="${line2}${SEP}${sd_color}${seven_d_int}%${RESET} 7d"
+fi
+
+printf '%b\n' "${line1}"
+printf '%b\n' "${line2}"
+```
+
+**Hacer ejecutable**:
+
+```bash
+chmod +x <ruta elegida>/statusline-command.sh
+```
+
+---
+
+## PASO P5 — Actualizar `settings.json`
+
+### Definir el valor a escribir
+
+El campo `statusLine` que se añadirá/reemplazará en el JSON es:
+
+**Scope global** (`~/.claude/settings.json`):
+
+```json
+"statusLine": {
+  "type": "command",
+  "command": "bash ~/.claude/statusline-command.sh"
+}
+```
+
+**Scope proyecto** (`.claude/settings.json`):
+
+```json
+"statusLine": {
+  "type": "command",
+  "command": "bash .claude/statusline-command.sh"
+}
+```
+
+### Proceso de escritura (seguro, preserva el resto del JSON)
+
+1. **Read tool** sobre el `settings.json` elegido.
+2. Si el fichero no existe → base = `{}`.
+3. Si existe → parsear el JSON tal cual (no perder campos ni comentarios-no-JSON).
+4. **Actualizar** (o crear) la clave `statusLine` con el objeto anterior.
+5. **Serializar** preservando indentación (2 espacios, igual que el existente).
+6. **Write tool** con el contenido completo resultante.
+
+> ⚠️ **Prohibido**: usar `sed`/`awk` sobre el JSON o reemplazos de texto.
+> Sólo Read → parse → Write.
+
+> ⚠️ **Preservar** todos los demás campos del fichero (hooks, permissions,
+> preferences, etc.). Si el JSON es inválido o tiene comentarios no
+> estándar, parar y mostrar el fichero al usuario sin modificar.
+
+---
+
+## PASO P6 — Confirmación final con lore
+
+Mostrar sin interacción (sustituir `<ruta>` y `<config>` según scope):
+
+```
+══════════════════════════════════════════════════════════════════
+🥔 ¡El Status Line de Pépeton ha sido instalado!
+
+  📜 Script:  <ruta del statusline-command.sh>
+  ⚙️  Config:  <ruta del settings.json> → statusLine
+
+  Haz cualquier interacción con Claude Code para verlo en acción.
+  Si no ves las barras de 5h/7d, es normal hasta la primera
+  respuesta de la sesión (son datos Pro/Max).
+
+  "Que el código fluya limpio y los prompts encuentren
+   siempre su camino de vuelta."
+        — Pépeton hijo de Móreuton
+══════════════════════════════════════════════════════════════════
+```
+
+Volver al **menú principal de Palantír** (`00-menu-principal.md`, PASO 2).
+
+---
+
+## ⚠️ Reglas globales del módulo
+
+1. **Nunca escribir** sin confirmación explícita del usuario (PASO P3).
+2. **Preservar** todos los campos del `settings.json` al actualizar.
+3. **Usar solo** Read + Write tools sobre JSON, nunca `sed`/`awk`/text-replace.
+4. **No contaminar** `MEMORY.md` ni auto memory durante este flujo.
+5. **Idempotencia**: ejecutar el preset dos veces seguidas debe dejar el
+   sistema en el mismo estado final (no duplicar scripts ni campos).
+6. **Si el usuario cancela** en cualquier AskUserQuestion → no tocar nada
+   y volver al menú principal.
+
+---
+
+*Status Line — Preset de Pépeton · Palantír Módulo 07c v1.0 · 🥔*

--- a/prompts/tlotp-main.md
+++ b/prompts/tlotp-main.md
@@ -227,7 +227,7 @@ Nunca actúa sin confirmación.
 🗺️ **Épicas Disponibles**
 
 ⚔️ **🔮 Palantír** — La Piedra Vidente. Domina las configuraciones de tu reino.
-   *(CLAUDE.md · settings.json · rules/ · hooks · MEMORY.md)*
+   *(CLAUDE.md · settings.json · rules/ · hooks · MEMORY.md · Status Line)*
 ⚔️ **🌳 Ents** — Los Pastores del Fangorn. Custodian las ramas y optimizan tu CI/CD.
    *(.github/workflows/ · GitHub Actions)*
 ⚔️ **⚒️ Celebrimbor** — El Maestro Herrero Élfico forja skills como anillos de poder.

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -108,7 +108,8 @@ modules_for_epic() {
 04-exploracion-custom|Exploracion de settings.json, skills/, hooks/
 05-susurrar-planes|Anadir configuracion con analisis inteligente
 06-compartir-visiones|Importar, exportar y eliminar configuraciones
-07-status-line|CRUD de Status Line
+07-status-line|CRUD de Status Line (crear, editar, reemplazar, eliminar)
+07c-status-line-pepeton|Preset de Pepeton: 2 lineas con barras de contexto, 5h y 7d
 MODS
     ;;
     bardo) cat <<'MODS'


### PR DESCRIPTION
## Summary

Closes #428. Three improvements to Palantír's Status Line management:

1. **`tlotp-main.md`** now mentions **Status Line** in Palantír's one-liner description, so users discover the feature from the top menu.
2. **Informative banner** before any interactive menu in `07a` (creation) and `07b` (management) explaining what Palantír can and cannot do, plus the JSON fields available on input (`model`, `workspace`, `cost`, `context_window`, `rate_limits`, `session_id`, `git_worktree`, `vim.mode`…).
3. **New preset "🥔 Usar el status line de Pépeton, hijo de Móreuton"** available from both `07a` and `07b`, routed to the new module `prompts/palantir/sections/07c-status-line-pepeton.md`.

## The Pépeton preset

A 2-line status line with adaptive colours:

```
~/dir  ·   branch  ·  Sonnet 4.6  ·  $0.0412
████░░░░░░ 38% ctx  ·  ██░░░░░░░░ 22% 5h  ·  9% 7d
```

- **Line 1** — dir · branch · model · cost (with total_cost_usd fallback computed from token counts)
- **Line 2** — context bar · 5h bar · 7d %
- **Adaptive colours**: green <50 / yellow <80 / red ≥80
- **5h / 7d bars** hide themselves when the fields aren't present (non-Pro/Max)
- **Requirements**: `jq`, `git`, `bash`

**Installation flow** (module `07c`, 6 steps):
1. Lore + preset description
2. `jq` / `git` dependency check (warn, allow continue if jq missing)
3. Scope detection (global / project / replace existing)
4. Write `statusline-command.sh` + `chmod +x`
5. Atomic `settings.json` update (Read → parse → update → Write, preserves all other fields)
6. Pépeton-themed confirmation

## Files changed

| File | Change |
|------|--------|
| `prompts/tlotp-main.md` | +1 -1 (Palantír description includes `· Status Line`) |
| `prompts/palantir/palantir-main.md` | +2 (import + listing) |
| `prompts/palantir/sections/07a-status-line-create.md` | +36 -2 (banner + 🥔 option) |
| `prompts/palantir/sections/07b-status-line-manage.md` | +72 -6 (banner + paginated 3+1 menu to fit 5 options) |
| `prompts/palantir/sections/07c-status-line-pepeton.md` | new, 353 lines (module + embedded script) |
| `scripts/compile.sh` | +2 -1 (`modules_for_epic palantir` registers 07c) |

## Local validation

- `bash scripts/compile.sh` → 90 HTML modules (was 89; +1 = new 07c)
- `bash scripts/verify-compile.sh` → **8987 hrefs verified across 97 HTML files, OK**
- Compiled artefacts checked:
  - `dist/palantir/palantir-main.md` includes the full 07c module (3 occurrences of `07c-status-line-pepeton`)
  - `dist/tlotp-main.html` mentions "Status Line" in Palantír's description
  - `dist/palantir/index.html` tabla de módulos lista la entrada de Pépeton
  - `dist/palantir/sections/07b-status-line-manage.html` incluye 🥔 en el menú paginado

## SDD

Full SDD in [`.claude/sdd/428-palantir-statusline-pepeton/`](https://github.com/joseguillermomoreu-gif/tlotp/tree/feature/t428_palantir_statusline_pepeton/.claude/sdd/428-palantir-statusline-pepeton).

## Test plan

- [ ] CI green (markdown-lint, @prompts check, external-links, import-lint, compile-check with new check_internal_hrefs from #423)
- [ ] Manual review of the Pépeton lore and preset script
- [ ] Confirm Palantír menu paginated flow (3+1) in `07b` still leads to the right routing

Refs #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)