### PR TITLE
feat(bardo): add plugin suggestion module for detected stack

### DIFF
--- a/prompts/bardo/bardo-main.md
+++ b/prompts/bardo/bardo-main.md
@@ -180,6 +180,11 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir de Lake-
 - Menú interactivo: el usuario elige sobre qué quiere más info
 - Bardo explica con ejemplos del stack real del proyecto
 
+### "🔌 Instalar plugins recomendados para mi stack" *(accesible desde "Inspeccionar el arsenal")*
+- Cargar módulo: `sections/05-module-suggest-plugins.md`
+- Flujo asistido: un plugin a la vez, con elección de scope antes de instalar
+- Solo disponible cuando "Inspeccionar el arsenal" detecta plugins sugeridos no instalados
+
 ### "🔌 Conseguir un plugin en el mercado — Buscar e instalar plugin"
 - Cargar módulo: `sections/02-module-install-plugins.md`
 - Búsqueda en marketplace oficial de plugins
@@ -221,5 +226,5 @@ Cargar `@prompts/tlotp-main.md` para retomar el menú principal de TLOTP.
 
 ---
 
-**Módulos nuevos**: `00-module-analyze`, `01-module-guide`, `02-module-install-plugins`, `03-module-install-mcps`, `04-module-docs`
+**Módulos nuevos**: `00-module-analyze`, `01-module-guide`, `02-module-install-plugins`, `03-module-install-mcps`, `04-module-docs`, `05-module-suggest-plugins`
 **Módulos legacy** (referencia): `01-mcp-analysis`, `02-plugins-analysis`, `03-stack-detection`, `04-marketplace`, `05-recommendations`, `06-install-wizard`, `07-verification`, `08-el-trovador`

--- a/prompts/bardo/sections/00-module-analyze.md
+++ b/prompts/bardo/sections/00-module-analyze.md
@@ -163,7 +163,20 @@ Score global = media de puntuaciones individuales (redondeado a 1 decimal)
 
 ## Paso 4 — MCPs y plugins recomendados no instalados
 
-Basado en el stack detectado y la documentación oficial, listar qué podría ser útil:
+### Catálogo de plugins oficiales (AMPLIAR AQUÍ con nuevos plugins)
+
+Cruzar el stack detectado contra este catálogo. Para cada plugin:
+- Si su stack disparador está presente en el stack detectado **Y** el plugin **no** está instalado → incluir en sugeridos.
+- Si ya está instalado → no mencionar nunca.
+
+| Stack disparador | Plugin ID | Descripción | Instalaciones |
+|-----------------|-----------|-------------|---------------|
+| React / Vue / Angular / Svelte | `frontend-design@claude-plugins-official` | Genera UI con tipografía, paletas y animaciones distintivas. Evita el "AI slop aesthetic". | 277.000+ |
+| TypeScript | `typescript@claude-plugins-official` | Mejora la inferencia y sugerencias para proyectos TypeScript. | — |
+| Python | `python@claude-plugins-official` | Optimiza asistencia en proyectos Python: patrones, idioms, tipado. | — |
+| GitHub (directorio `.github/` detectado o repo git) | `github@claude-plugins-official` | Integración con flujos de GitHub: issues, PRs, Actions. | — |
+
+Basado en el stack detectado, la documentación oficial y el catálogo anterior, listar qué podría ser útil:
 
 ```
 💡 OPORTUNIDADES DETECTADAS PARA TU STACK
@@ -175,9 +188,22 @@ Basado en el stack detectado y la documentación oficial, listar qué podría se
     • postgres-mcp    — acceso directo a tu DB desde Claude
 
   🔌 Plugins recomendados no instalados:
-    • (basado en docs/en/discover-plugins, WebFetch ya cargado)
+    • frontend-design@claude-plugins-official
+      Genera UI con tipografía, paletas y animaciones distintivas.
+      (Stack disparador: React detectado · 277.000+ instalaciones)
+    • typescript@claude-plugins-official
+      Mejora la inferencia y sugerencias para proyectos TypeScript.
+      (Stack disparador: TypeScript detectado)
 ──────────────────────────────────────────────────────────────
 ```
+
+Si no hay plugins sugeridos (todos instalados o el stack no mapea a ninguno del catálogo):
+```
+  🔌 Plugins: tu carcaj ya está bien equipado para el stack detectado.
+```
+
+**Guardar la lista de plugins sugeridos en el contexto de sesión** para pasarla a
+`sections/05-module-suggest-plugins.md` si el usuario elige instalarlos.
 
 ---
 
@@ -206,8 +232,8 @@ Mostrar total: `X mejoras encontradas (Y ❌ críticas · Z ⚠️ mejorables ·
         "description": ""
       },
       {
-        "label": "🔌 Buscar e instalar los recomendados",
-        "description": "Solo si se detectaron oportunidades"
+        "label": "🔌 Instalar plugins recomendados para mi stack",
+        "description": "Solo si se detectaron plugins sugeridos en el Paso 4"
       },
       {
         "label": "🔙 Volver al menú principal",
@@ -218,7 +244,11 @@ Mostrar total: `X mejoras encontradas (Y ❌ críticas · Z ⚠️ mejorables ·
 }
 ```
 
-> **Nota**: la opción de instalar recomendados solo aparece si se detectaron oportunidades en el Paso 4.
+> **Nota**: la opción de instalar plugins recomendados solo aparece si hay plugins sugeridos en el Paso 4
+> (es decir, plugins del catálogo cuyo stack disparador fue detectado y no están ya instalados).
+>
+> **Acción al elegir "Instalar plugins recomendados"**: cargar `sections/05-module-suggest-plugins.md`
+> pasando la lista de plugins sugeridos calculada en el Paso 4.
 
 ---
 

--- a/prompts/bardo/sections/05-module-suggest-plugins.md
+++ b/prompts/bardo/sections/05-module-suggest-plugins.md
@@ -1,0 +1,276 @@
+# 🔌 Módulo: Sugerir e Instalar Plugins Oficiales Recomendados
+
+## Misión
+
+Presentar al usuario, uno a uno, los plugins oficiales de Claude Code que son relevantes
+para su stack y no están instalados. Gestionar la instalación asistida con elección de scope
+y confirmación post-instalación.
+
+---
+
+## Paso 0 — Recibir contexto
+
+**Si viene desde `00-module-analyze.md`** (flujo normal):
+Usar directamente la lista de plugins sugeridos calculada en el Paso 4 de ese módulo.
+No repetir el análisis de stack ni la detección de instalados.
+
+**Si llega directamente sin contexto previo** (llegada directa al módulo):
+Ejecutar detección mínima en una sola llamada Bash:
+
+```bash
+{
+  echo "=== STACK ==="
+  ls package.json composer.json pyproject.toml go.mod Cargo.toml pom.xml .github 2>/dev/null
+  cat package.json 2>/dev/null | head -20
+  cat composer.json 2>/dev/null | head -10
+
+  echo "=== PLUGINS INSTALADOS ==="
+  cat .claude/settings.json 2>/dev/null || echo "{}"
+  cat ~/.claude/settings.json 2>/dev/null || echo "{}"
+} 2>/dev/null
+```
+
+Cruzar el resultado con el catálogo del Paso 4 de `00-module-analyze.md` para obtener la lista
+de plugins sugeridos.
+
+**Si no hay plugins sugeridos** (todos instalados o stack no mapea):
+```
+🏹 Tu arsenal ya está bien equipado, viajero.
+
+   No se encontraron plugins oficiales pendientes de instalar
+   para el stack detectado. Cada flecha de tu carcaj ya está en su sitio.
+
+🏹 "Bardo no dispara flechas que ya han llegado."
+```
+Ir directamente al Paso 4 (continuación).
+
+---
+
+## Paso 1 — Presentar y gestionar plugins uno a uno
+
+Para cada plugin de la lista de sugeridos (iterar en orden), mostrar:
+
+```
+══════════════════════════════════════════════════════════════
+🏹 Bardo detectó: [stack disparador del plugin]
+
+  Plugin sugerido ([X]/[N]): [plugin-id]
+  ¿Qué hace? [descripción del catálogo en 2-3 líneas]
+  Instalaciones: [número o "dato no disponible en este momento"]
+
+══════════════════════════════════════════════════════════════
+```
+
+**AskUserQuestion por cada plugin**:
+
+```json
+{
+  "questions": [{
+    "header": "Plugin sugerido [X/N]",
+    "question": "🏹 ¿Lo instalamos?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Sí, instalar",
+        "description": ""
+      },
+      {
+        "label": "📖 Más información",
+        "description": "Ver detalles completos del plugin"
+      },
+      {
+        "label": "⏭️ No, saltar",
+        "description": ""
+      },
+      {
+        "label": "🚫 Cancelar todo",
+        "description": "Abortar y ver resumen"
+      }
+    ]
+  }]
+}
+```
+
+**Comportamiento por opción**:
+
+### Si elige "✅ Sí, instalar"
+→ Ir al **Paso 2a** (elegir scope).
+
+### Si elige "📖 Más información"
+Comprobar si `docs/en/discover-plugins` ya está en contexto de la sesión.
+- **Si ya está**: mostrar información detallada del plugin directamente.
+- **Si no está**: hacer WebFetch on-demand a `https://code.claude.com/docs/en/discover-plugins`
+  y extraer la información específica del plugin.
+
+**Fallback si WebFetch falla**:
+```
+⚠️ No se pudo cargar la documentación oficial en este momento.
+   Descripción disponible: [descripción del catálogo interno]
+   Fuente: https://code.claude.com/docs/en/discover-plugins
+```
+
+Mostrar la información adicional y volver a preguntar sí/no para **ese mismo plugin**:
+
+```json
+{
+  "questions": [{
+    "header": "Plugin sugerido [X/N] — tras ver más info",
+    "question": "🏹 ¿Lo instalamos?",
+    "multiSelect": false,
+    "options": [
+      { "label": "✅ Sí, instalar", "description": "" },
+      { "label": "⏭️ No, saltar", "description": "" }
+    ]
+  }]
+}
+```
+
+### Si elige "⏭️ No, saltar"
+```
+🏹 "Esta flecha puede esperar su momento..."
+```
+Continuar al siguiente plugin de la lista.
+
+### Si elige "🚫 Cancelar todo"
+Ir directamente al **Paso 3** (resumen final).
+
+---
+
+## Paso 2a — Elegir scope
+
+```json
+{
+  "questions": [{
+    "header": "Scope de instalación",
+    "question": "¿Dónde instalar [plugin-id]?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🌍 Global — disponible en todos mis proyectos",
+        "description": ""
+      },
+      {
+        "label": "📂 Proyecto — solo en este proyecto",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+---
+
+## Paso 2b — Ejecutar instalación
+
+Mostrar el comando antes de ejecutarlo:
+```
+🔌 Instalando [plugin-id]...
+```
+
+Ejecutar según el scope elegido:
+- **Global**: `/plugin install [plugin-id]`
+- **Proyecto**: `/plugin install [plugin-id] --scope project`
+
+**Si el comando falla** (error de red, plugin no encontrado, etc.):
+```
+⚠️ No se pudo instalar [plugin-id].
+
+   Puedes intentarlo manualmente:
+     /plugin install [plugin-id]
+
+   O consultar el marketplace oficial:
+     https://claude.com/plugins/[nombre-sin-scope]
+```
+Continuar con el siguiente plugin (no abortar el flujo completo).
+
+---
+
+## Paso 2c — Confirmación post-instalación
+
+```
+══════════════════════════════════════════════════════════════
+✅ Plugin instalado: [plugin-id]
+   Se activará automáticamente en tu próximo contexto relevante.
+   No necesitas invocar ningún comando.
+══════════════════════════════════════════════════════════════
+
+🏹 "Una flecha más en el carcaj de Lake-town.
+    Smaug no lo verá venir, viajero."
+```
+
+Continuar al siguiente plugin de la lista.
+
+---
+
+## Paso 3 — Resumen final
+
+Tras procesar todos los plugins (o tras "Cancelar todo"):
+
+```
+📋 RESUMEN DE PLUGINS
+══════════════════════════════════════════════════════════════
+  ✅ Instalados: [X]
+  ⏭️  Saltados:   [X]
+  ❌ Fallidos:   [X]  (solo si hubo errores de instalación)
+══════════════════════════════════════════════════════════════
+🏹  "El carcaj de Bardo nunca está vacío. Hasta la próxima cacería."
+```
+
+Si todos fueron instalados correctamente:
+```
+🏹 Arsenal completo, viajero. Smaug no tiene escapatoria.
+```
+
+---
+
+## Paso 4 — Continuación
+
+```json
+{
+  "questions": [{
+    "header": "Plugins gestionados",
+    "question": "🏹 ¿Qué deseas hacer ahora?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🔙 Volver al menú de Bardo",
+        "description": ""
+      },
+      {
+        "label": "🔙 Volver a La Comunidad del Código",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+**Si elige "Volver a La Comunidad del Código"**: cargar `@prompts/tlotp-main.md`.
+
+---
+
+## Catálogo de referencia (sincronizado con `00-module-analyze.md`)
+
+> **IMPORTANTE**: mantener sincronizado con el catálogo del Paso 4 de `00-module-analyze.md`.
+
+| Plugin ID | Stack disparador | Descripción | Instalaciones |
+|-----------|-----------------|-------------|---------------|
+| `frontend-design@claude-plugins-official` | React / Vue / Angular / Svelte | Genera UI con tipografía, paletas y animaciones distintivas. Evita el "AI slop aesthetic". | 277.000+ |
+| `typescript@claude-plugins-official` | TypeScript | Mejora la inferencia y sugerencias para proyectos TypeScript. | — |
+| `python@claude-plugins-official` | Python | Optimiza asistencia en proyectos Python: patrones, idioms, tipado. | — |
+| `github@claude-plugins-official` | GitHub (directorio `.github/` o repo git) | Integración con flujos de GitHub: issues, PRs, Actions. | — |
+
+---
+
+## 🔗 Fuentes
+
+Ver índice completo en `@prompts/docs-sources.md`:
+- Plugins: `https://code.claude.com/docs/en/plugins`
+- Discover plugins: `https://code.claude.com/docs/en/discover-plugins`
+- Marketplace oficial: `https://claude.com/plugins/`
+
+---
+
+**Módulo**: `05-module-suggest-plugins.md`
+**Invocado desde**: `00-module-analyze.md` (opción "Instalar plugins recomendados para mi stack")
+**Requiere**: Bash (detección mínima si llegada directa), WebFetch on-demand (solo para "más info")

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -118,6 +118,7 @@ MODS
 02-module-install-plugins|Buscar e instalar plugins desde marketplace|Anadir un plugin nuevo con verificacion
 03-module-install-mcps|Buscar e instalar MCPs con scope y transport|Anadir un MCP (stdio, sse) al entorno correcto
 04-module-docs|Los pergaminos del Arquero — guia completa|Consultar documentacion en tiempo real
+05-module-suggest-plugins|Sugerir e instalar plugins oficiales por stack|Instalar plugins recomendados segun el stack detectado
 MODS
     ;;
     celebrimbor) cat <<'MODS'


### PR DESCRIPTION
## Summary

- Añade `05-module-suggest-plugins.md`: flujo asistido que guía al usuario para instalar plugins recomendados uno a uno, con elección de scope antes de cada instalación
- Actualiza `00-module-analyze.md`: incorpora catálogo oficial de plugins cruzado contra el stack detectado, con lógica clara de inclusión/exclusión en sugerencias
- Actualiza `bardo-main.md`: registra el nuevo módulo y su punto de entrada desde "Inspeccionar el arsenal"
- Actualiza `compile.sh`: añade entrada para el nuevo módulo en el listado de Bardo

## Test plan

- [ ] Ejecutar "Inspeccionar el arsenal" en un proyecto con React/TypeScript → verificar que aparece la opción "Instalar plugins recomendados para mi stack"
- [ ] Ejecutar "Inspeccionar el arsenal" en un proyecto sin stack mapeado al catálogo → verificar que la opción NO aparece
- [ ] Elegir "Instalar plugins recomendados" → verificar que carga `05-module-suggest-plugins.md` con la lista de plugins del Paso 4
- [ ] Seguir el flujo de instalación asistida → verificar que instala un plugin a la vez con elección de scope
- [ ] Verificar que `compile.sh` incluye correctamente el nuevo módulo

🤖 Generated with [Claude Code](https://claude.com/claude-code)