### PR TITLE
chore: revert VERSION.md to v8.1.0 for release prep

### DIFF
--- a/prompts/VERSION.md
+++ b/prompts/VERSION.md
@@ -1,7 +1,7 @@
 # TLOTP - Version
 
-**TLOTP v8.2.0** — "El Guardián Inmune"
-**Fecha release**: 2026-04-23
+**TLOTP v8.1.0** — "La Flecha Certera"
+**Fecha release**: 2026-04-20
 
 ## Componentes
 


### PR DESCRIPTION
Revierte VERSION.md a v8.1.0 para que el workflow release-prep pueda hacer el bump correctamente a v8.2.0 "El Guardián Inmune".