### PR TITLE
feat(bardo): reorganizar menú por categorías + integrar Caveman [#444]

### DIFF
--- a/prompts/VERSION.md
+++ b/prompts/VERSION.md
@@ -1,7 +1,7 @@
 # TLOTP - Version
 
-**TLOTP v8.2.0** — "El Guardián Inmune"
-**Fecha release**: 2026-04-23
+**TLOTP v8.3.0** — "El Cavernícola de Lake-town"
+**Fecha release**: 2026-04-29
 
 ## Componentes
 

--- a/prompts/bardo/bardo-main.md
+++ b/prompts/bardo/bardo-main.md
@@ -2,8 +2,8 @@
 
 ## Misión
 
-Gestionar el entry point de Bardo: mostrar el banner, presentar la guía
-de bienvenida y enrutar al módulo correspondiente.
+Entry point de Bardo: banner, intro y enrutado mediante menú principal
+de 1 pantalla con submenús por categoría.
 
 **NOTA**: En todos los banners, reemplaza `{VERSION}` con la versión TLOTP cargada desde `@prompts/VERSION.md`.
 
@@ -67,22 +67,55 @@ de bienvenida y enrutar al módulo correspondiente.
 
 ---
 
-## 🏹 Menú Principal (PAGINADO)
+## 🏹 Menú Principal (1 pantalla, submenús por categoría)
 
-**CRÍTICO**: Usar **AskUserQuestion** (límite 4 opciones). El menú se divide en 3 pantallas.
-Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir de Lake-town" (última página: "🔙 Volver al inicio" en lugar de "➕ Ver más...").
-
-**Pantalla 1** (mostrar primero):
+**CRÍTICO**: Usar **AskUserQuestion** (límite 4 opciones). El menú principal
+agrupa por categorías; cada categoría con varias acciones abre un submenú.
 
 ```json
 {
   "questions": [{
-    "header": "El Arsenal de Lake-town (1/3)",
+    "header": "El Arsenal de Lake-town",
     "question": "🏹 ¿Qué necesitas, viajero?",
     "multiSelect": false,
     "options": [
       {
-        "label": "🎯 Inspeccionar el arsenal — Analizar stack, MCPs y plugins actuales",
+        "label": "🎯 Mi arsenal — Inspeccionar y consultar mis MCPs/plugins",
+        "description": ""
+      },
+      {
+        "label": "🛒 El mercado — Conseguir plugins, MCPs y herramientas nuevas",
+        "description": ""
+      },
+      {
+        "label": "📜 Pergaminos del Arquero — Guía completa MCPs y plugins",
+        "description": ""
+      },
+      {
+        "label": "🚪 Salir de Lake-town",
+        "description": ""
+      }
+    ]
+  }]
+}
+```
+
+**Loop continuo**: al terminar cada módulo o submenú, volver a este menú principal
+**sin re-renderizar banner, intro ni permisos**.
+
+---
+
+## 🎯 Submenú: Mi arsenal
+
+```json
+{
+  "questions": [{
+    "header": "🎯 Mi arsenal",
+    "question": "¿Qué quieres hacer con tu arsenal actual?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "🎯 Inspeccionar el arsenal — Analizar stack, MCPs y plugins",
         "description": ""
       },
       {
@@ -90,11 +123,7 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir de Lake-
         "description": ""
       },
       {
-        "label": "➕ Ver más...",
-        "description": ""
-      },
-      {
-        "label": "🚪 Salir de Lake-town",
+        "label": "🔙 Volver al menú Bardo",
         "description": ""
       }
     ]
@@ -102,29 +131,34 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir de Lake-
 }
 ```
 
-**Si elige "➕ Ver más..."**, mostrar **Pantalla 2**:
+**Comportamiento `🔙 Volver al menú Bardo`**: volver al menú principal **sin re-renderizar
+banner ni intro**.
+
+---
+
+## 🛒 Submenú: El mercado
 
 ```json
 {
   "questions": [{
-    "header": "El Arsenal de Lake-town (2/3)",
-    "question": "🏹 ¿Qué necesitas, viajero?",
+    "header": "🛒 El mercado de Lake-town",
+    "question": "¿Qué quieres conseguir?",
     "multiSelect": false,
     "options": [
       {
-        "label": "🔌 Conseguir un plugin en el mercado — Buscar e instalar plugin",
+        "label": "🔌 Plugin marketplace — Buscar e instalar plugin oficial",
         "description": ""
       },
       {
-        "label": "🔗 Conseguir un MCP en el mercado — Buscar e instalar MCP",
+        "label": "🔗 MCP marketplace — Buscar e instalar MCP",
         "description": ""
       },
       {
-        "label": "➕ Ver más...",
+        "label": "🪨 Caveman — Reducir tokens 65-75% (plugin de tercero)",
         "description": ""
       },
       {
-        "label": "🚪 Salir de Lake-town",
+        "label": "🔙 Volver al menú Bardo",
         "description": ""
       }
     ]
@@ -132,99 +166,95 @@ Patrón fijo: 2 opciones de contenido + "➕ Ver más..." + "🚪 Salir de Lake-
 }
 ```
 
-**Si elige "➕ Ver más..."**, mostrar **Pantalla 3**:
+**Comportamiento `🔙 Volver al menú Bardo`**: volver al menú principal **sin re-renderizar
+banner ni intro**.
+
+---
+
+## 🚪 Submenú: Salir de Lake-town
 
 ```json
 {
   "questions": [{
-    "header": "El Arsenal de Lake-town (3/3)",
-    "question": "🏹 ¿Qué necesitas, viajero?",
+    "header": "🚪 Salir de Lake-town",
+    "question": "🏹 ¿Cerrar Lake-town o volver a La Comunidad?",
     "multiSelect": false,
     "options": [
       {
-        "label": "📜 Los pergaminos del Arquero — Guía completa MCPs y plugins",
-        "description": ""
+        "label": "🚪 Cerrar Lake-town definitivamente",
+        "description": "Despedida final del Arquero"
       },
       {
         "label": "🔙 Volver a La Comunidad del Código",
-        "description": ""
-      },
-      {
-        "label": "🔙 Volver al inicio",
-        "description": ""
-      },
-      {
-        "label": "🚪 Salir de Lake-town",
-        "description": ""
+        "description": "Retomar el menú principal de TLOTP"
       }
     ]
   }]
 }
 ```
-
-**Loop continuo**: al terminar cada módulo, volver a este menú (sin repetir banner, intro ni permisos).
 
 ---
 
 ## Flujo de Navegación
 
-### "🎯 Inspeccionar el arsenal — Analizar stack, MCPs y plugins actuales"
-- Cargar módulo: `sections/00-module-analyze.md`
-- Detectar stack del proyecto + leer MCPs y plugins instalados
-- Scoring por ítem + informe global
-- Revisor uno a uno de mejoras
+### `🎯 Mi arsenal` → submenú con:
 
-### "🗺️ Consultar al Contrabandista — Cómo usar mis MCPs y plugins"
-- Cargar módulo: `sections/01-module-guide.md`
-- Analizar MCPs/plugins actuales del usuario
-- Menú interactivo: el usuario elige sobre qué quiere más info
-- Bardo explica con ejemplos del stack real del proyecto
+- **Inspeccionar el arsenal** → cargar `sections/00-module-analyze.md`
+  Detectar stack, leer MCPs/plugins instalados, scoring por ítem y revisor de mejoras.
+- **Consultar al Contrabandista** → cargar `sections/01-module-guide.md`
+  Analizar MCPs/plugins actuales y explicar uso con ejemplos del stack real.
+- **🔙 Volver al menú Bardo** → menú principal (sin re-renderizar banner ni intro).
 
-### "🔌 Instalar plugins recomendados para mi stack" *(accesible desde "Inspeccionar el arsenal")*
-- Cargar módulo: `sections/05-module-suggest-plugins.md`
-- Flujo asistido: un plugin a la vez, con elección de scope antes de instalar
-- Solo disponible cuando "Inspeccionar el arsenal" detecta plugins sugeridos no instalados
+### `🛒 El mercado` → submenú con:
 
-### "🔌 Conseguir un plugin en el mercado — Buscar e instalar plugin"
-- Cargar módulo: `sections/02-module-install-plugins.md`
-- Búsqueda en marketplace oficial de plugins
-- Instalación guiada + verificación post-instalación
+- **Plugin marketplace** → cargar `sections/02-module-install-plugins.md`
+  Búsqueda en marketplace oficial + instalación guiada + verificación.
+- **MCP marketplace** → cargar `sections/03-module-install-mcps.md`
+  Búsqueda + elección de scope/transport + instalación guiada.
+- **🪨 Caveman** → cargar `sections/06-module-caveman.md`
+  Flujo dedicado de descubrimiento + instalación asistida del plugin de tercero.
+- **🔙 Volver al menú Bardo** → menú principal (sin re-renderizar banner ni intro).
 
-### "🔗 Conseguir un MCP en el mercado — Buscar e instalar MCP"
-- Cargar módulo: `sections/03-module-install-mcps.md`
-- Búsqueda + elección de scope (user/project) y transport
-- Instalación guiada + verificación post-instalación
+### `📜 Pergaminos del Arquero` (carga directa, sin submenú)
 
-### "📜 Los pergaminos del Arquero — Guía completa MCPs y plugins"
 - Cargar módulo: `sections/04-module-docs.md`
 - Preguntar nivel de detalle (completo / 5 min / 2 min)
 - WebFetch on-the-fly si las docs no están en contexto
+- Al terminar: volver al menú principal sin re-renderizar banner ni intro.
 
-### "🔙 Volver a La Comunidad del Código"
-```
-🏹 "La Flecha Negra siempre encuentra su objetivo.
-    Que tu arsenal sirva bien en la Tierra Media, viajero."
-```
-Cargar `@prompts/tlotp-main.md` para retomar el menú principal de TLOTP.
+### Acceso a `🔌 Instalar plugins recomendados para mi stack`
 
-### "🚪 Salir de Lake-town"
-```
-🏹 Lake-town cierra sus puertas al anochecer.
-   Que tus MCPs y plugins sirvan bien en la Tierra Media.
+Esta acción no aparece en el menú principal: se ofrece dentro del flujo de
+`🎯 Inspeccionar el arsenal` cuando se detectan plugins sugeridos no instalados.
+Carga `sections/05-module-suggest-plugins.md`.
 
-   Bardo guarda la Flecha Negra. Por ahora.
-```
+### `🚪 Salir de Lake-town` → submenú con:
+
+- **🚪 Cerrar Lake-town definitivamente**
+  ```
+  🏹 Lake-town cierra sus puertas al anochecer.
+     Que tus MCPs y plugins sirvan bien en la Tierra Media.
+
+     Bardo guarda la Flecha Negra. Por ahora.
+  ```
+- **🔙 Volver a La Comunidad del Código**
+  ```
+  🏹 "La Flecha Negra siempre encuentra su objetivo.
+      Que tu arsenal sirva bien en la Tierra Media, viajero."
+  ```
+  Cargar `@prompts/tlotp-main.md` para retomar el menú principal de TLOTP.
 
 ---
 
 ## Reglas de Ejecución
 
 1. **Banner e intro**: solo al entrar, nunca en el loop del menú
-2. **AskUserQuestion**: para navegación en todo momento
-3. **Loop continuo**: hasta que el usuario elija Salir
-4. **WebFetch on-demand**: nunca precargar docs oficiales
+2. **AskUserQuestion**: para navegación en todo momento (menú principal y submenús)
+3. **Submenús ≤ 4 opciones**: respetar el límite siempre, incluyendo `🔙 Volver`
+4. **Loop continuo sin re-render**: al volver de cualquier módulo o submenú, mostrar
+   solo el menú principal — banner, intro y permisos no se repiten
+5. **WebFetch on-demand**: nunca precargar docs oficiales
 
 ---
 
-**Módulos nuevos**: `00-module-analyze`, `01-module-guide`, `02-module-install-plugins`, `03-module-install-mcps`, `04-module-docs`, `05-module-suggest-plugins`
-**Módulos legacy** (referencia): `01-mcp-analysis`, `02-plugins-analysis`, `03-stack-detection`, `04-marketplace`, `05-recommendations`, `06-install-wizard`, `07-verification`, `08-el-trovador`
+**Módulos**: `00-module-analyze`, `01-module-guide`, `02-module-install-plugins`, `03-module-install-mcps`, `04-module-docs`, `05-module-suggest-plugins`, `06-module-caveman`

--- a/prompts/bardo/sections/00-module-analyze.md
+++ b/prompts/bardo/sections/00-module-analyze.md
@@ -167,14 +167,16 @@ Score global = media de puntuaciones individuales (redondeado a 1 decimal)
 
 Cruzar el stack detectado contra este catálogo. Para cada plugin:
 - Si su stack disparador está presente en el stack detectado **Y** el plugin **no** está instalado → incluir en sugeridos.
-- Si ya está instalado → no mencionar nunca.
+- Stack disparador `universal` → aplicable a cualquier stack (siempre se evalúa).
+- Si ya está instalado → no mencionar nunca (aplica también a Caveman: si `claude plugin list` lo detecta, se excluye de sugerencias).
 
-| Stack disparador | Plugin ID | Descripción | Instalaciones |
-|-----------------|-----------|-------------|---------------|
-| React / Vue / Angular / Svelte | `frontend-design@claude-plugins-official` | Genera UI con tipografía, paletas y animaciones distintivas. Evita el "AI slop aesthetic". | 277.000+ |
-| TypeScript | `typescript@claude-plugins-official` | Mejora la inferencia y sugerencias para proyectos TypeScript. | — |
-| Python | `python@claude-plugins-official` | Optimiza asistencia en proyectos Python: patrones, idioms, tipado. | — |
-| GitHub (directorio `.github/` detectado o repo git) | `github@claude-plugins-official` | Integración con flujos de GitHub: issues, PRs, Actions. | — |
+| Stack disparador | Plugin ID | Descripción | Origen | Instalaciones |
+|-----------------|-----------|-------------|--------|---------------|
+| React / Vue / Angular / Svelte | `frontend-design@claude-plugins-official` | Genera UI con tipografía, paletas y animaciones distintivas. Evita el "AI slop aesthetic". | oficial | 277.000+ |
+| TypeScript | `typescript@claude-plugins-official` | Mejora la inferencia y sugerencias para proyectos TypeScript. | oficial | — |
+| Python | `python@claude-plugins-official` | Optimiza asistencia en proyectos Python: patrones, idioms, tipado. | oficial | — |
+| GitHub (directorio `.github/` detectado o repo git) | `github@claude-plugins-official` | Integración con flujos de GitHub: issues, PRs, Actions. | oficial | — |
+| `universal` (cualquier stack) | `caveman@caveman` (de `JuliusBrussee/caveman`) | Reduce tokens de salida 65–75% comprimiendo respuestas a "estilo cavernícola". Niveles Lite/Full/Ultra/文言文. Flujo dedicado en `06-module-caveman.md`. | tercero | ~14.000 ⭐ |
 
 Basado en el stack detectado, la documentación oficial y el catálogo anterior, listar qué podría ser útil:
 
@@ -194,6 +196,9 @@ Basado en el stack detectado, la documentación oficial y el catálogo anterior,
     • typescript@claude-plugins-official
       Mejora la inferencia y sugerencias para proyectos TypeScript.
       (Stack disparador: TypeScript detectado)
+    • 🪨 caveman@caveman  (Origen: tercero · ~14.000 ⭐)
+      Reduce tokens de salida 65–75% (universal, cualquier stack).
+      Flujo dedicado: submenú "🛒 El mercado" → "🪨 Caveman".
 ──────────────────────────────────────────────────────────────
 ```
 

--- a/prompts/bardo/sections/05-module-suggest-plugins.md
+++ b/prompts/bardo/sections/05-module-suggest-plugins.md
@@ -253,12 +253,17 @@ Si todos fueron instalados correctamente:
 
 > **IMPORTANTE**: mantener sincronizado con el catálogo del Paso 4 de `00-module-analyze.md`.
 
-| Plugin ID | Stack disparador | Descripción | Instalaciones |
-|-----------|-----------------|-------------|---------------|
-| `frontend-design@claude-plugins-official` | React / Vue / Angular / Svelte | Genera UI con tipografía, paletas y animaciones distintivas. Evita el "AI slop aesthetic". | 277.000+ |
-| `typescript@claude-plugins-official` | TypeScript | Mejora la inferencia y sugerencias para proyectos TypeScript. | — |
-| `python@claude-plugins-official` | Python | Optimiza asistencia en proyectos Python: patrones, idioms, tipado. | — |
-| `github@claude-plugins-official` | GitHub (directorio `.github/` o repo git) | Integración con flujos de GitHub: issues, PRs, Actions. | — |
+| Plugin ID | Stack disparador | Descripción | Origen | Instalaciones |
+|-----------|-----------------|-------------|--------|---------------|
+| `frontend-design@claude-plugins-official` | React / Vue / Angular / Svelte | Genera UI con tipografía, paletas y animaciones distintivas. Evita el "AI slop aesthetic". | oficial | 277.000+ |
+| `typescript@claude-plugins-official` | TypeScript | Mejora la inferencia y sugerencias para proyectos TypeScript. | oficial | — |
+| `python@claude-plugins-official` | Python | Optimiza asistencia en proyectos Python: patrones, idioms, tipado. | oficial | — |
+| `github@claude-plugins-official` | GitHub (directorio `.github/` o repo git) | Integración con flujos de GitHub: issues, PRs, Actions. | oficial | — |
+| `caveman@caveman` (de `JuliusBrussee/caveman`) | `universal` (cualquier stack) | Reduce tokens de salida 65–75% comprimiendo respuestas a "estilo cavernícola". Niveles Lite/Full/Ultra/文言文. Flujo dedicado en `06-module-caveman.md`. | tercero | ~14.000 ⭐ |
+
+> **AMPLIAR AQUÍ**: añadir nuevas filas manteniendo sincronía con `00-module-analyze.md`.
+> Para plugins de tercero, marcar `Origen: tercero` y considerar un módulo dedicado en
+> `sections/` si requieren flujo de instalación distinto al estándar.
 
 ---
 

--- a/prompts/bardo/sections/06-module-caveman.md
+++ b/prompts/bardo/sections/06-module-caveman.md
@@ -1,0 +1,246 @@
+# 🪨 Módulo: Caveman — Plugin de tercero (reducción de tokens)
+
+> **Origen: tercero** — `JuliusBrussee/caveman` (~14.000 ⭐) · No es un plugin
+> oficial de Claude Code. Bardo lo presenta como herramienta del mercado por su
+> impacto medible en tokens de salida.
+
+## Misión
+
+Descubrir, presentar e instalar de forma asistida el plugin Caveman, que
+reduce los tokens de salida 65–75% comprimiendo respuestas a "estilo cavernícola".
+El usuario decide en cada paso; nada se ejecuta sin confirmación explícita.
+
+---
+
+## Paso 0 — Detectar si Caveman ya está instalado
+
+```bash
+claude plugin list 2>/dev/null | grep -i caveman || true
+```
+
+**Si la salida contiene `caveman`** → ramificar a **Paso 0b (ya instalado)**.
+**Si está vacía** → continuar a Paso 1.
+
+### Paso 0b — Caveman ya instalado
+
+```
+══════════════════════════════════════════════════════════════
+🪨 Caveman ya está instalado en tu arsenal.
+══════════════════════════════════════════════════════════════
+
+   Estado: activo (plugin de tercero, JuliusBrussee/caveman)
+   Activar:    /caveman
+   Desactivar: stop caveman
+   Niveles:    Lite · Full · Ultra · 文言文
+```
+
+**AskUserQuestion**:
+
+```json
+{
+  "questions": [{
+    "header": "🪨 Caveman ya instalado",
+    "question": "¿Qué quieres hacer?",
+    "multiSelect": false,
+    "options": [
+      { "label": "ℹ️ Ver más información (WebFetch al repo)", "description": "" },
+      { "label": "🛑 Mostrar cómo desactivar", "description": "" },
+      { "label": "🔙 Volver al menú Bardo", "description": "" }
+    ]
+  }]
+}
+```
+
+- **Ver más información** → WebFetch on-demand a `https://github.com/JuliusBrussee/caveman`
+  y mostrar resumen. Volver a este AskUserQuestion.
+- **Mostrar cómo desactivar** → mostrar `stop caveman` con explicación. Volver al menú Bardo.
+- **🔙 Volver al menú Bardo** → menú principal sin re-renderizar banner ni intro.
+
+---
+
+## Paso 1 — Presentación del plugin
+
+```
+══════════════════════════════════════════════════════════════
+🪨  CAVEMAN — El Cavernícola de Lake-town
+══════════════════════════════════════════════════════════════
+
+  📦 Identidad
+     Plugin: caveman@caveman
+     Repo:   JuliusBrussee/caveman
+     ⭐      ~14.000
+     Origen: tercero (no es plugin oficial de Claude Code)
+
+  ⚡ Beneficio
+     Reduce tokens de salida 65–75% comprimiendo respuestas
+     a "estilo cavernícola" (telegráfico, sin florituras).
+
+  🎚️ Niveles disponibles
+     • Lite    — recorte suave (~30%)
+     • Full    — modo cavernícola completo (~65%)
+     • Ultra   — máxima compresión (~75%)
+     • 文言文  — modo chino clásico (curiosidad cultural)
+
+  🛠️ Sub-skills incluidos
+     /caveman-commit    — mensajes de commit comprimidos
+     /caveman-review    — code review en estilo cavernícola
+     /caveman-compress  — comprimir cualquier texto a la fuerza
+     /caveman-help      — ayuda del plugin
+
+  ▶️ Comandos
+     Activar:    /caveman
+     Desactivar: stop caveman
+
+  🏹 Lore del Arquero
+     "Donde el Arquero gasta una flecha, el Cavernícola gasta una piedra.
+      Misma presa. Menos materiales. Lake-town aprueba el trueque."
+
+══════════════════════════════════════════════════════════════
+```
+
+---
+
+## Paso 2 — Decisión del usuario
+
+```json
+{
+  "questions": [{
+    "header": "🪨 Caveman — ¿Lo instalamos?",
+    "question": "🏹 ¿Qué deseas hacer con esta piedra?",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "✅ Sí, instalar Caveman",
+        "description": "Bardo añadirá el marketplace y ejecutará la instalación"
+      },
+      {
+        "label": "ℹ️ Más información (consultar el repo)",
+        "description": "WebFetch on-demand a github.com/JuliusBrussee/caveman"
+      },
+      {
+        "label": "⏭️ No, saltar",
+        "description": "Volver al menú Bardo sin instalar"
+      },
+      {
+        "label": "🚫 Cancelar",
+        "description": "Volver al menú Bardo"
+      }
+    ]
+  }]
+}
+```
+
+### Comportamiento por opción
+
+- **✅ Sí, instalar Caveman** → ir al **Paso 3**.
+- **ℹ️ Más información**:
+  - WebFetch on-demand a `https://github.com/JuliusBrussee/caveman`
+  - Mostrar resumen extraído (descripción extendida, ejemplos, niveles)
+  - **Volver a este Paso 2** (re-preguntar instalar / saltar / cancelar)
+- **⏭️ No, saltar**:
+  ```
+  🏹 "Hoy el Cavernícola se queda en la cueva. Otro día, viajero."
+  ```
+  Volver al menú Bardo (sin re-renderizar banner ni intro).
+- **🚫 Cancelar** → volver al menú Bardo (sin re-renderizar banner ni intro).
+
+---
+
+## Paso 3 — Instalación asistida
+
+> **Confirmación explícita ya recibida en Paso 2**. Solo se ejecuta tras `✅ Sí`.
+
+Mostrar antes de ejecutar:
+
+```
+🪨 Instalando Caveman (plugin de tercero)...
+
+   Comandos a ejecutar:
+     1) claude plugin marketplace add JuliusBrussee/caveman
+     2) claude plugin install caveman@caveman
+```
+
+Ejecutar en orden estricto:
+
+```bash
+claude plugin marketplace add JuliusBrussee/caveman
+claude plugin install caveman@caveman
+```
+
+**Si el primer comando falla** (marketplace ya añadido, error de red, etc.):
+- Capturar el mensaje y continuar al segundo solo si el error es "marketplace already added".
+- Si es otro error, abortar y mostrar el fallback (ver más abajo).
+
+**Si el segundo comando falla**:
+```
+⚠️ No se pudo instalar Caveman.
+
+   Puedes intentarlo manualmente:
+     claude plugin marketplace add JuliusBrussee/caveman
+     claude plugin install caveman@caveman
+
+   Repo oficial (origen tercero): https://github.com/JuliusBrussee/caveman
+```
+Volver al menú Bardo.
+
+---
+
+## Paso 4 — Activación post-instalación
+
+```
+══════════════════════════════════════════════════════════════
+✅ Caveman instalado correctamente
+══════════════════════════════════════════════════════════════
+
+  ▶️ Para activarlo:
+     /caveman
+
+  🛑 Para desactivarlo:
+     stop caveman
+
+  🎚️ Niveles disponibles:
+     Lite · Full · Ultra · 文言文
+
+  🛠️ Sub-skills disponibles:
+     /caveman-commit    — commits comprimidos
+     /caveman-review    — code review cavernícola
+     /caveman-compress  — comprimir texto a la fuerza
+     /caveman-help      — ayuda del plugin
+
+══════════════════════════════════════════════════════════════
+
+🏹 "Una piedra más en el carcaj. Smaug arderá igual,
+    pero esta vez con la mitad de tokens, viajero."
+```
+
+---
+
+## Paso 5 — Continuación
+
+Volver al menú principal de Bardo **sin re-renderizar banner, intro ni permisos**.
+El loop continuo del módulo principal toma el control.
+
+---
+
+## Notas de mantenimiento
+
+- **Versión observada**: comandos verificados en abril 2026. Si el plugin cambia su
+  flujo de instalación o activación, actualizar este módulo.
+- **Origen tercero**: marcado explícitamente en cabecera, Paso 1, Paso 2 (descripción
+  de "Sí, instalar") y fallback de Paso 3.
+- **Sin scripts externos**: solo se usan los comandos oficiales `claude plugin
+  marketplace add` y `claude plugin install`. No se ejecuta código del repo de tercero.
+- **Sin persistencia de credenciales**: Caveman no requiere ni almacena secretos.
+
+---
+
+## 🔗 Fuentes
+
+- Repo oficial (tercero): `https://github.com/JuliusBrussee/caveman`
+- Plugins Claude Code: `https://code.claude.com/docs/en/plugins`
+
+---
+
+**Módulo**: `06-module-caveman.md`
+**Invocado desde**: `bardo-main.md` (submenú "🛒 El mercado" → "🪨 Caveman")
+**Requiere**: Bash (detección + instalación), WebFetch on-demand (solo en "Más información")


### PR DESCRIPTION
## Summary

Reorganización del menú principal de Bardo en submenús por categoría e integración del nuevo módulo **Caveman** (gestor de plugins/extensiones).

## Cambios

- **`prompts/bardo/bardo-main.md`** — Rediseño del menú principal con submenús por categoría
- **`prompts/bardo/sections/06-module-caveman.md`** — Nuevo módulo Caveman (gestión de plugins)
- **`prompts/bardo/sections/00-module-analyze.md`** — Sincronización del catálogo Caveman en el módulo de análisis
- **`prompts/bardo/sections/05-module-suggest-plugins.md`** — Sincronización del catálogo Caveman en sugerencias
- **`prompts/VERSION.md`** — Bump a **v8.3.0** "El Cavernícola de Lake-town"

## Commits

1. `feat(bardo): rediseñar menú principal con submenús por categoría`
2. `feat(bardo): añadir módulo Caveman (06-module-caveman.md)`
3. `feat(bardo): sincronizar catálogo Caveman en analyze y suggest-plugins`
4. `chore: bump TLOTP v8.3.0 "El Cavernícola de Lake-town"`

## Test plan

- [ ] CI verde (markdown lint, @imports internos, links externos, ciclos de imports)
- [ ] Verificar que `bardo-main.md` referencia correctamente todas las secciones (incluida la 06)
- [ ] Verificar que el catálogo Caveman es coherente entre `analyze`, `suggest-plugins` y `caveman`
- [ ] Validar versión v8.3.0 en `VERSION.md`

Closes #444