### PR TITLE
chore: revert version bump to allow release-prep workflow

### DIFF
--- a/prompts/VERSION.md
+++ b/prompts/VERSION.md
@@ -1,7 +1,7 @@
 # TLOTP - Version
 
-**TLOTP v8.3.0** — "El Cavernícola de Lake-town"
-**Fecha release**: 2026-04-29
+**TLOTP v8.2.0** — "El Guardián Inmune"
+**Fecha release**: 2026-04-23
 
 ## Componentes
 


### PR DESCRIPTION
## Summary

Revierte el bump manual de versión a v8.3.0 "El Cavernícola de Lake-town" para permitir que el workflow `release-prep.yml` realice el bump oficial automáticamente.

Restaura `prompts/VERSION.md` a v8.2.0 "El Guardián Inmune" (release del 2026-04-23).

## Test plan

- [ ] CI verde sobre la PR
- [ ] Tras el merge, lanzar `release-prep.yml` con `bump_type=minor` y `release_name="El Cavernícola de Lake-town"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)