### PR TITLE
fix(palantir): status line visible en mini-guía + templates PS1/SH publicados

### DIFF
--- a/prompts/palantir/sections/01-mini-guide.md
+++ b/prompts/palantir/sections/01-mini-guide.md
@@ -27,6 +27,9 @@ cómo Claude piensa y actúa en tu entorno.
 
 🧠 MEMORY.md       — La memoria persistente entre batallas
 
+📊 Status Line     — La barra de estado dinámica de Claude Code
+                     (crear, editar, reemplazar; disponible en "Ver más →")
+
 ⚔️ ¿Qué puede hacer Palantír?
   🔍 Inspeccionar — leer el estado actual de toda tu configuración
   ➕ Añadir       — crear nuevos registros con asistencia inteligente

--- a/prompts/palantir/sections/07c-status-line-pepeton.md
+++ b/prompts/palantir/sections/07c-status-line-pepeton.md
@@ -132,15 +132,33 @@ Si la carpeta `.claude/` no existe en el scope elegido, crearla con `mkdir -p`.
 
 ### Leer template versionado y escribir
 
-Según `SHELL_TARGET`:
+Según `SHELL_TARGET`, descargar el template desde la URL pública vía `Bash`:
 
-- **bash** → `Read prompts/palantir/templates/statusline-command.sh`
-- **powershell** → `Read prompts/palantir/templates/statusline-command.ps1`
+- **bash**:
 
-**Escribir** el contenido leído tal cual en la ruta destino con `Write` tool.
+  ```bash
+  curl -fsSL https://josemoreupeso.es/tlotp/palantir/templates/statusline-command.sh
+  ```
+
+- **powershell**:
+
+  ```bash
+  curl -fsSL https://josemoreupeso.es/tlotp/palantir/templates/statusline-command.ps1
+  ```
+
+Capturar el output completo en una variable. Verificar que no está vacío antes
+de continuar (un 200 con body vacío sería un deploy roto).
+
+> ⚠️ **Fallback** (sin red, HTTP ≠ 200, output vacío): usar
+> `Read prompts/palantir/templates/statusline-command.{sh|ps1}` como fuente
+> secundaria. Si tampoco existe el fichero local, abortar con un mensaje de
+> error claro al usuario (no improvisar el contenido del script).
+
+**Escribir** el contenido obtenido tal cual en la ruta destino con `Write` tool.
 
 > 🚫 **Prohibido** duplicar el cuerpo del script en este markdown. La fuente
-> de verdad es exclusivamente el fichero versionado del repo. Si necesitas
+> de verdad es exclusivamente el fichero versionado del repo (servido también
+> en `https://josemoreupeso.es/tlotp/palantir/templates/`). Si necesitas
 > modificar el script, hazlo en `prompts/palantir/templates/` vía PR.
 
 ### Permisos ejecutables (solo bash)

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1489,6 +1489,22 @@ function toggleSidebar(){document.getElementById('sidebar').classList.toggle('op
 INDEXEOF4
 }
 
+# ── Copiar assets non-.md de prompts/ a dist/ ────────────────
+# Issue #482: scripts/templates (.ps1, .sh) y cualquier futuro asset non-md
+# deben publicarse al sitio para que 07c pueda hacer curl desde una máquina
+# sin el repo clonado. Mantiene la ruta relativa origen → destino.
+copy_non_md_assets() {
+  local count=0
+  while IFS= read -r asset; do
+    local rel="${asset#$PROMPTS_DIR/}"
+    local dest="$DIST_DIR/$rel"
+    mkdir -p "$(dirname "$dest")"
+    cp "$asset" "$dest"
+    count=$((count + 1))
+  done < <(find "$PROMPTS_DIR" -type f ! -name "*.md" | sort)
+  echo "  Copied $count non-.md asset(s) to dist/"
+}
+
 # ── Compilar todo ────────────────────────────────────────────
 compile_all() {
   echo "=== TLOTP Compiler ==="
@@ -1526,6 +1542,9 @@ compile_all() {
   # 5. Generate main index.html
   generate_index
 
+  # 6. Copy non-.md assets (templates, scripts, etc.) — issue #482
+  copy_non_md_assets
+
   echo ""
   echo "=== Compilation complete ==="
   echo "  HTML modules:    $count"
@@ -1533,6 +1552,7 @@ compile_all() {
   echo "  AI .md (1:1):    dist/**/*.md (one per source, .md URLs)"
   echo "  Epic index:      dist/{epic}/index.html (x7)"
   echo "  Landing page:    dist/index.html"
+  echo "  Non-md assets:   dist/**/* (copied 1:1 from prompts/)"
 }
 
 # ── Main ─────────────────────────────────────────────────────

--- a/scripts/smoke-urls.txt
+++ b/scripts/smoke-urls.txt
@@ -31,3 +31,8 @@ https://josemoreupeso.es/tlotp/tom-bombadil/index.html
 # (sirven como smoke del pipeline compile.sh → dist → rsync)
 https://josemoreupeso.es/tlotp/palantir/palantir-main.html
 https://josemoreupeso.es/tlotp/palantir/palantir-main.md
+
+# Templates de Status Line (publicados por compile.sh → dist/ → rsync) — issue #482
+# 07c-status-line-pepeton.md hace curl a estas URLs como fuente primaria.
+https://josemoreupeso.es/tlotp/palantir/templates/statusline-command.ps1
+https://josemoreupeso.es/tlotp/palantir/templates/statusline-command.sh

--- a/scripts/verify-compile.sh
+++ b/scripts/verify-compile.sh
@@ -302,6 +302,20 @@ check_ai_md_pipeline() {
 
 check_ai_md_pipeline
 
+# 13. Verify non-.md assets are copied (templates) — issue #482
+#     compile.sh debe copiar prompts/**/*.{ps1,sh,...} a dist/ con la misma
+#     ruta relativa. Sin este paso, 07c-status-line-pepeton no puede hacer
+#     curl desde una máquina sin el repo clonado.
+for asset in palantir/templates/statusline-command.ps1 \
+             palantir/templates/statusline-command.sh; do
+  if [ -f "$DIST_DIR/$asset" ]; then
+    echo "  [OK] dist/$asset exists"
+  else
+    echo "  ERROR: dist/$asset not found (compile.sh debe copiarlo)"
+    errors=$((errors + 1))
+  fi
+done
+
 echo ""
 if [ "$errors" -gt 0 ]; then
   echo "FAILED: $errors error(s) detected"


### PR DESCRIPTION
## Resumen

Cierra #482. Dos bugs detectados probando en equipo nuevo (Windows + PowerShell).

- **Status Line invisible**: añadida al bloque informativo de `01-mini-guide.md` (primera pantalla de Palantír, sin tocar el menú paginado 3+1)
- **Templates PS1/SH no publicados (404)**: `compile.sh` ahora copia assets non-`.md` de `prompts/` a `dist/` (Paso 6) → se despliegan vía rsync → disponibles como URL pública
- **07c web-first**: `curl -fsSL` como fuente primaria del template, fallback a `Read` local si no hay red
- **smoke-urls.txt**: URLs de templates añadidas para validación post-deploy

## Cambios

| Archivo | Cambio |
|---|---|
| `prompts/palantir/sections/01-mini-guide.md` | `📊 Status Line` visible en primera pantalla |
| `scripts/compile.sh` | función `copy_non_md_assets()` — Paso 6 |
| `scripts/verify-compile.sh` | Check 13: verifica `dist/palantir/templates/*.{ps1,sh}` |
| `prompts/palantir/sections/07c-status-line-pepeton.md` | PASO P4: `curl` primario + fallback `Read` |
| `scripts/smoke-urls.txt` | 2 URLs de templates añadidas |

## Test plan

- [ ] CI verde (compile-check, lint-imports, validate-statusline-templates)
- [ ] Post-merge: smoke test URLs de templates devuelven HTTP 200
- [ ] Verificar en equipo sin repo clonado: preset Pépeton instala PS1 correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)